### PR TITLE
[JAX] Cartpole

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # data files
 *.hdf5
+*.mp4
+*.png
 
 # developer-specific files
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.hdf5
 *.mp4
 *.png
+*.swp
 
 # developer-specific files
 .vscode

--- a/examples/control/mppi_cart_pole/__main__.py
+++ b/examples/control/mppi_cart_pole/__main__.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+import sys
+
+import click
+import jax
+import jax.numpy as jnp
+
+from ss.control import MPPIController
+from ss.system import CartPoleSystem, simulate
+
+from .cost import CostWeights
+from .post_processing import (
+    plot_simulation,
+    render_animation,
+)
+
+
+@click.command()
+@click.option(
+    "--duration", type=click.FloatRange(min=0, min_open=True), default=5.0
+)
+@click.option(
+    "--time-step", type=click.FloatRange(min=0, min_open=True), default=0.02
+)
+@click.option("--horizon", type=click.IntRange(min=1), default=60)
+@click.option("--num-samples", type=click.IntRange(min=1), default=1024)
+@click.option(
+    "--temperature",
+    type=click.FloatRange(min=0, min_open=True),
+    default=2.0,
+)
+@click.option(
+    "--noise-sigma",
+    type=click.FloatRange(min=0, min_open=True),
+    default=10.0,
+)
+@click.option(
+    "--control-limit",
+    type=click.FloatRange(min=0, min_open=True),
+    default=40.0,
+)
+@click.option("--initial-angle", type=float, default=0.8)
+@click.option("--save-dir", type=click.Path(file_okay=False, path_type=Path))
+def main(
+    duration: float,
+    time_step: float,
+    horizon: int,
+    num_samples: int,
+    temperature: float,
+    noise_sigma: float,
+    control_limit: float,
+    initial_angle: float,
+    save_dir: Path | None,
+) -> None:
+    num_steps = round(duration / time_step)
+    system = CartPoleSystem(time_step=time_step, batch_size=1)
+    rollout_system = CartPoleSystem(
+        time_step=time_step, batch_size=num_samples
+    )
+    weights = CostWeights()
+
+    random_key = jax.random.PRNGKey(0)
+    state = jnp.array([[0.0, 0.0, initial_angle, 0.0]])
+    controller = MPPIController(
+        control_dim=system.control_dim,
+        batch_size=system.batch_size,
+        rollout_system=rollout_system,
+        running_cost=weights.running_cost,
+        terminal_cost=weights.terminal_cost,
+        horizon=horizon,
+        num_samples=num_samples,
+        temperature=temperature,
+        noise_sigma=noise_sigma,
+        control_limit=control_limit,
+    )
+    random_keys = jax.random.split(random_key, num_steps)
+    times, states, _, controls = simulate(
+        system,
+        0.0,
+        state,
+        random_keys,
+        controller=controller,
+    )
+    costs = weights.running_cost(states[:, 0, :], controls[:, 0, :])
+    click.echo(f"final_state={states[-1, 0]}")
+    click.echo(f"total_running_cost={jnp.sum(costs) * time_step}")
+
+    if save_dir is not None:
+        save_dir.mkdir(parents=True, exist_ok=True)
+        plot_simulation(
+            times,
+            states,
+            controls,
+            costs,
+            save_dir / "mppi_cart_pole_plot.png",
+        )
+        render_animation(
+            times, states, system.pole_length, save_dir / "mppi_cart_pole.mp4"
+        )
+        click.echo(f"Saved MPPI results to {save_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/control/mppi_cart_pole/__main__.py
+++ b/examples/control/mppi_cart_pole/__main__.py
@@ -58,10 +58,9 @@ def main(
     weights = CostWeights()
 
     random_key = jax.random.PRNGKey(0)
-    state = jnp.broadcast_to(
-        jnp.array([0.0, 0.0, initial_angle, 0.0]),
-        (batch_size, system.state_dim),
-    )
+    initial_key, simulation_key = jax.random.split(random_key)
+    state = system.init_state(initial_key)
+    state = state.at[:, 2].add(initial_angle)
     controller = MPPIController(
         control_dim=system.control_dim,
         batch_size=system.batch_size,
@@ -74,7 +73,7 @@ def main(
         noise_sigma=noise_sigma,
         control_limit=control_limit,
     )
-    random_keys = jax.random.split(random_key, num_steps)
+    random_keys = jax.random.split(simulation_key, num_steps)
     times, states, _, controls = simulate(
         system,
         0.0,

--- a/examples/control/mppi_cart_pole/__main__.py
+++ b/examples/control/mppi_cart_pole/__main__.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import sys
 
 import click
 import jax
@@ -24,6 +23,7 @@ from .post_processing import (
 )
 @click.option("--horizon", type=click.IntRange(min=1), default=60)
 @click.option("--num-samples", type=click.IntRange(min=1), default=1024)
+@click.option("--batch-size", type=click.IntRange(min=1), default=1)
 @click.option(
     "--temperature",
     type=click.FloatRange(min=0, min_open=True),
@@ -46,6 +46,7 @@ def main(
     time_step: float,
     horizon: int,
     num_samples: int,
+    batch_size: int,
     temperature: float,
     noise_sigma: float,
     control_limit: float,
@@ -53,18 +54,18 @@ def main(
     save_dir: Path | None,
 ) -> None:
     num_steps = round(duration / time_step)
-    system = CartPoleSystem(time_step=time_step, batch_size=1)
-    rollout_system = CartPoleSystem(
-        time_step=time_step, batch_size=num_samples
-    )
+    system = CartPoleSystem(time_step=time_step, batch_size=batch_size)
     weights = CostWeights()
 
     random_key = jax.random.PRNGKey(0)
-    state = jnp.array([[0.0, 0.0, initial_angle, 0.0]])
+    state = jnp.broadcast_to(
+        jnp.array([0.0, 0.0, initial_angle, 0.0]),
+        (batch_size, system.state_dim),
+    )
     controller = MPPIController(
         control_dim=system.control_dim,
         batch_size=system.batch_size,
-        rollout_system=rollout_system,
+        rollout_system=system,
         running_cost=weights.running_cost,
         terminal_cost=weights.terminal_cost,
         horizon=horizon,
@@ -81,9 +82,9 @@ def main(
         random_keys,
         controller=controller,
     )
-    costs = weights.running_cost(states[:, 0, :], controls[:, 0, :])
-    click.echo(f"final_state={states[-1, 0]}")
-    click.echo(f"total_running_cost={jnp.sum(costs) * time_step}")
+    costs = weights.running_cost(states, controls)
+    click.echo(f"final_state={states[-1]}")
+    click.echo(f"total_running_cost={jnp.sum(costs, axis=0) * time_step}")
 
     if save_dir is not None:
         save_dir.mkdir(parents=True, exist_ok=True)

--- a/examples/control/mppi_cart_pole/__main__.py
+++ b/examples/control/mppi_cart_pole/__main__.py
@@ -59,7 +59,8 @@ def main(
 
     random_key = jax.random.PRNGKey(0)
     initial_key, simulation_key = jax.random.split(random_key)
-    state = system.init_state(initial_key)
+    initial_key, initial_system_key = jax.random.split(initial_key)
+    state = system.init_state(initial_system_key)
     state = state.at[:, 2].add(initial_angle)
     controller = MPPIController(
         control_dim=system.control_dim,
@@ -80,6 +81,7 @@ def main(
         state,
         random_keys,
         controller=controller,
+        initial_key=initial_key,
     )
     costs = weights.running_cost(states, controls)
     click.echo(f"final_state={states[-1]}")

--- a/examples/control/mppi_cart_pole/__main__.py
+++ b/examples/control/mppi_cart_pole/__main__.py
@@ -60,7 +60,7 @@ def main(
     random_key = jax.random.PRNGKey(0)
     initial_key, simulation_key = jax.random.split(random_key)
     initial_key, initial_system_key = jax.random.split(initial_key)
-    state = system.init_state(initial_system_key)
+    state = system.initial_state(initial_system_key)
     state = state.at[:, 2].add(initial_angle)
     controller = MPPIController(
         control_dim=system.control_dim,

--- a/examples/control/mppi_cart_pole/cost.py
+++ b/examples/control/mppi_cart_pole/cost.py
@@ -13,16 +13,18 @@ class CostWeights(eqx.Module):
 
     def state_cost(self, state: Array) -> Array:
         """Quadratic state cost about the upright origin."""
-        angle_error = jnp.arctan2(jnp.sin(state[:, 2]), jnp.cos(state[:, 2]))
+        angle_error = jnp.arctan2(
+            jnp.sin(state[..., 2]), jnp.cos(state[..., 2])
+        )
         return (
-            self.cart_position * state[:, 0] ** 2
-            + self.cart_velocity * state[:, 1] ** 2
+            self.cart_position * state[..., 0] ** 2
+            + self.cart_velocity * state[..., 1] ** 2
             + self.pole_angle * angle_error**2
-            + self.pole_angular_velocity * state[:, 3] ** 2
+            + self.pole_angular_velocity * state[..., 3] ** 2
         )
 
     def running_cost(self, state: Array, control: Array) -> Array:
-        return self.state_cost(state) + self.control * control[:, 0] ** 2
+        return self.state_cost(state) + self.control * control[..., 0] ** 2
 
     def terminal_cost(self, state: Array) -> Array:
         return self.terminal_scale * self.state_cost(state)

--- a/examples/control/mppi_cart_pole/cost.py
+++ b/examples/control/mppi_cart_pole/cost.py
@@ -1,0 +1,28 @@
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array
+
+
+class CostWeights(eqx.Module):
+    cart_position: float = 2.0
+    cart_velocity: float = 0.2
+    pole_angle: float = 12.0
+    pole_angular_velocity: float = 0.5
+    control: float = 0.002
+    terminal_scale: float = 10.0
+
+    def state_cost(self, state: Array) -> Array:
+        """Quadratic state cost about the upright origin."""
+        angle_error = jnp.arctan2(jnp.sin(state[:, 2]), jnp.cos(state[:, 2]))
+        return (
+            self.cart_position * state[:, 0] ** 2
+            + self.cart_velocity * state[:, 1] ** 2
+            + self.pole_angle * angle_error**2
+            + self.pole_angular_velocity * state[:, 3] ** 2
+        )
+
+    def running_cost(self, state: Array, control: Array) -> Array:
+        return self.state_cost(state) + self.control * control[:, 0] ** 2
+
+    def terminal_cost(self, state: Array) -> Array:
+        return self.terminal_scale * self.state_cost(state)

--- a/examples/control/mppi_cart_pole/post_processing.py
+++ b/examples/control/mppi_cart_pole/post_processing.py
@@ -1,0 +1,146 @@
+from pathlib import Path
+
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+from jaxtyping import Array
+from matplotlib.animation import FFMpegWriter, FuncAnimation
+from matplotlib.patches import Circle
+
+
+def plot_simulation(
+    times: Array,
+    states: Array,
+    controls: Array,
+    running_costs: Array,
+    save_path: Path,
+) -> None:
+    """Plot the state, control, and cost of an MPPI simulation."""
+    figure, axes = plt.subplots(
+        3, 2, figsize=(12, 10), sharex=True, constrained_layout=True
+    )
+    series = (
+        (0, "Cart position", "Position (m)"),
+        (2, "Pole angle", "Angle (rad)"),
+        (1, "Cart velocity", "Velocity (m/s)"),
+        (3, "Pole angular velocity", "Angular velocity (rad/s)"),
+    )
+    for axis, (state_index, title, ylabel) in zip(
+        axes[:2].flat, series, strict=True
+    ):
+        for batch_index in range(states.shape[1]):
+            axis.plot(
+                times,
+                states[:, batch_index, state_index],
+                linewidth=1.3,
+                alpha=0.8,
+                label=f"Run {batch_index + 1}",
+            )
+        axis.set_title(title)
+        axis.set_ylabel(ylabel)
+        axis.grid(alpha=0.3)
+
+    if states.shape[1] > 1 and states.shape[1] <= 10:
+        axes[0, 0].legend(ncols=2, fontsize="small")
+
+    for batch_index in range(controls.shape[1]):
+        axes[2, 0].plot(
+            times,
+            controls[:, batch_index, 0],
+            linewidth=1.3,
+            alpha=0.8,
+        )
+    axes[2, 0].set_title("MPPI control")
+    axes[2, 0].set_ylabel("Force (N)")
+    axes[2, 0].grid(alpha=0.3)
+
+    axes[2, 1].plot(times, running_costs, color="tab:purple")
+    axes[2, 1].set_title("Running cost")
+    axes[2, 1].set_ylabel("Cost")
+    axes[2, 1].grid(alpha=0.3)
+
+    for axis in axes[-1]:
+        axis.set_xlabel("Time (s)")
+    figure.suptitle("MPPI cart-pole simulation")
+    figure.savefig(save_path, dpi=160)
+    plt.close(figure)
+
+
+def render_animation(
+    times: Array,
+    states: Array,
+    pole_length: float,
+    save_path: Path,
+    fps: int = 30,
+) -> None:
+    """Render cart-pole trajectories as an MP4 animation."""
+    duration = times[-1] - times[0]
+    num_steps = times.shape[0]
+    frame_count = min(num_steps, max(2, round(duration * fps)))
+    frame_indices = jnp.linspace(0, num_steps - 1, frame_count, dtype=int)
+
+    marker_radius = max(0.08, 0.06 * pole_length)
+    x_positions = states[:, :, 0]
+    horizontal_margin = pole_length + marker_radius
+
+    figure, axis = plt.subplots(figsize=(10, 5), constrained_layout=True)
+    axis.set_xlim(
+        x_positions.min() - horizontal_margin,
+        x_positions.max() + horizontal_margin,
+    )
+    axis.set_ylim(-pole_length - marker_radius, pole_length + marker_radius)
+    axis.set_aspect("equal", adjustable="box")
+    axis.set_xlabel("Horizontal position (m)")
+    axis.set_ylabel("Vertical position (m)")
+    axis.set_title("MPPI cart-pole simulation")
+    axis.grid(alpha=0.25)
+    axis.axhline(0, color="0.3", linewidth=2)
+
+    colors = plt.colormaps["tab10"](
+        jnp.linspace(0, 1, states.shape[1], endpoint=False)
+    )
+    mechanisms = []
+    for color in colors:
+        cart = Circle(
+            (0, 0),
+            marker_radius,
+            facecolor=color,
+            edgecolor="black",
+            alpha=0.8,
+            zorder=4,
+        )
+        axis.add_patch(cart)
+        (pole,) = axis.plot([], [], color=color, linewidth=4, zorder=5)
+        bob = Circle((0, 0), marker_radius, color=color, zorder=6)
+        axis.add_patch(bob)
+        mechanisms.append((cart, pole, bob))
+
+    time_label = axis.text(0.02, 0.95, "", transform=axis.transAxes)
+
+    def update(frame_index: int):
+        state_index = frame_indices[frame_index]
+        artists = []
+        for batch_index, mechanism in enumerate(mechanisms):
+            cart, pole, bob = mechanism
+            cart_position = states[state_index, batch_index, 0]
+            pole_angle = states[state_index, batch_index, 2]
+            bob_x = cart_position + pole_length * jnp.sin(pole_angle)
+            bob_y = pole_length * jnp.cos(pole_angle)
+
+            cart.center = (cart_position, 0)
+            pole.set_data((cart_position, bob_x), (0, bob_y))
+            bob.center = (bob_x, bob_y)
+            artists.extend(mechanism)
+
+        time_label.set_text(f"t = {times[state_index]:.2f} s")
+        return *artists, time_label
+
+    animation = FuncAnimation(
+        figure,
+        update,
+        frames=frame_count,
+        interval=1000 / fps,
+        blit=True,
+    )
+    writer = FFMpegWriter(fps=fps, metadata={"title": "Cart-pole simulation"})
+    animation.save(save_path, writer=writer, dpi=140)
+    plt.close(figure)

--- a/examples/control/mppi_cart_pole/post_processing.py
+++ b/examples/control/mppi_cart_pole/post_processing.py
@@ -53,7 +53,13 @@ def plot_simulation(
     axes[2, 0].set_ylabel("Force (N)")
     axes[2, 0].grid(alpha=0.3)
 
-    axes[2, 1].plot(times, running_costs, color="tab:purple")
+    for batch_index in range(running_costs.shape[1]):
+        axes[2, 1].plot(
+            times,
+            running_costs[:, batch_index],
+            linewidth=1.3,
+            alpha=0.8,
+        )
     axes[2, 1].set_title("Running cost")
     axes[2, 1].set_ylabel("Cost")
     axes[2, 1].grid(alpha=0.3)

--- a/examples/estimation/filtering/hmm_filter/__main__.py
+++ b/examples/estimation/filtering/hmm_filter/__main__.py
@@ -12,7 +12,7 @@ import jax
 import jax.numpy as jnp
 
 from ss.system.discrete import HiddenMarkovModel
-from ss.system import simulate, batch_simulate
+from ss.system import simulate
 
 from ss.estimation.filtering.hmm import HmmFilter
 from ss.estimation.filtering import filtering, batch_filtering
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     print("=== single rollout ===")
     time_horizon = 10
 
-    initial_state = jnp.array(0, dtype=jnp.int32)
+    initial_state = system.initial_state(random_key)
     random_keys = jax.random.split(random_key, time_horizon)
 
     times, states, observations, _ = simulate(
@@ -62,12 +62,15 @@ if __name__ == "__main__":
 
     print("=== batch filtering ===")
     batch_size = 5
+    systems = system.duplicate(batch_size=batch_size)
 
-    init_states = jnp.tile(jnp.array(0, dtype=jnp.int32), (batch_size, 1))
-    random_keys = jax.random.split(random_key, (batch_size, time_horizon))
+    initial_state_key, random_key = jax.random.split(random_key)
+    initial_state_keys = jax.random.split(initial_state_key, batch_size)
+    init_states = systems.initial_state(initial_state_keys)
+    random_keys = jax.random.split(random_key, time_horizon)
 
-    batch_times, batch_states, batch_observations, _ = batch_simulate(
-        system, 0, init_states, random_keys
+    batch_times, batch_states, batch_observations, _ = simulate(
+        systems, 0, init_states, random_keys
     )
 
     print("batch_times shape:", batch_times.shape)

--- a/examples/system/cart_pole/__main__.py
+++ b/examples/system/cart_pole/__main__.py
@@ -3,10 +3,8 @@ from pathlib import Path
 import click
 import jax
 
-from ss.system import simulate
+from ss.system import CartPoleSystem, simulate
 
-# User-defined-system
-from .cart_pole_system import CartPoleSystem
 from .post_processing import plot_simulation, render_animation
 
 

--- a/examples/system/cart_pole/__main__.py
+++ b/examples/system/cart_pole/__main__.py
@@ -78,7 +78,7 @@ def main(
     random_key = jax.random.PRNGKey(0)
     initial_key, simulation_key = jax.random.split(random_key)
 
-    initial_state = system.init_state(initial_key)
+    initial_state = system.initial_state(initial_key)
     random_keys = jax.random.split(simulation_key, num_steps)
 
     times, states, _, _ = simulate(

--- a/examples/system/cart_pole/__main__.py
+++ b/examples/system/cart_pole/__main__.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+
+import click
+import jax
+import jax.numpy as jnp
+
+from ss.system import simulate
+
+# User-defined-system
+from .cart_pole_system import CartPoleSystem
+from .post_processing import plot_simulation, render_animation
+
+
+@click.command()
+@click.option(
+    "--duration",
+    type=click.FloatRange(min=0, min_open=True),
+    default=10.0,
+    help="Set the duration to run system (positive value).",
+)
+@click.option(
+    "--cart-mass",
+    type=click.FloatRange(min=0, min_open=True),
+    default=1.0,
+    help="Set the mass of the cart (positive value).",
+)
+@click.option(
+    "--pole-mass",
+    type=click.FloatRange(min=0, min_open=True),
+    default=0.01,
+    help="Set the mass of the pole (positive value).",
+)
+@click.option(
+    "--pole-length",
+    type=click.FloatRange(min=0, min_open=True),
+    default=2.0,
+    help="Set the length of the pole (positive value).",
+)
+@click.option(
+    "--gravity",
+    type=click.FloatRange(min=0),
+    default=9.81,
+    help="Set the value of gravity (positive value).",
+)
+@click.option(
+    "--time-step",
+    type=click.FloatRange(min=0, min_open=True),
+    default=0.01,
+    help="Set the time step (positive value).",
+)
+@click.option(
+    "--batch-size",
+    type=click.IntRange(min=1),
+    default=1,
+    help="Set the batch size (positive integers).",
+)
+@click.option(
+    "--save-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Save the trajectory plot and MP4 animation in this directory.",
+)
+def main(
+    duration: float,
+    cart_mass: float,
+    pole_mass: float,
+    pole_length: float,
+    gravity: float,
+    time_step: float,
+    batch_size: int,
+    save_dir: Path | None,
+) -> None:
+    num_steps = round(duration / time_step)
+    system = CartPoleSystem(
+        cart_mass=cart_mass,
+        pole_mass=pole_mass,
+        pole_length=pole_length,
+        gravity=gravity,
+        time_step=time_step,
+        batch_size=batch_size,
+    )
+    random_key = jax.random.PRNGKey(0)
+    initial_key, simulation_key = jax.random.split(random_key)
+
+    initial_state = system.init_state(initial_key)
+    random_keys = jax.random.split(simulation_key, num_steps)
+
+    control_policy = lambda time, observation: jnp.zeros(
+        (batch_size, system.control_dim)
+    )
+
+    times, states, _, _ = simulate(
+        system, 0.0, initial_state, random_keys, control_policy
+    )
+
+    print(f"final_state={states[-1]}")
+
+    if save_dir is not None:
+        save_dir.mkdir(parents=True, exist_ok=True)
+
+        plot_path = save_dir / "cart_pole_plot.png"
+        animation_path = save_dir / "cart_pole_animation.mp4"
+
+        plot_simulation(times, states, save_path=plot_path)
+        render_animation(times, states, pole_length, animation_path)
+
+        click.echo(f"Saved plot to {plot_path}")
+        click.echo(f"Saved animation to {animation_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/system/cart_pole/__main__.py
+++ b/examples/system/cart_pole/__main__.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import click
 import jax
-import jax.numpy as jnp
 
 from ss.system import simulate
 
@@ -84,12 +83,11 @@ def main(
     initial_state = system.init_state(initial_key)
     random_keys = jax.random.split(simulation_key, num_steps)
 
-    control_policy = lambda time, observation: jnp.zeros(
-        (batch_size, system.control_dim)
-    )
-
     times, states, _, _ = simulate(
-        system, 0.0, initial_state, random_keys, control_policy
+        system,
+        0.0,
+        initial_state,
+        random_keys,
     )
 
     print(f"final_state={states[-1]}")

--- a/examples/system/cart_pole/cart_pole_system.py
+++ b/examples/system/cart_pole/cart_pole_system.py
@@ -1,5 +1,6 @@
 import jax
 import jax.numpy as jnp
+import equinox as eqx
 from jaxtyping import Array, Float, PRNGKeyArray
 
 from ss.system import System
@@ -23,16 +24,16 @@ class CartPoleSystem(System):
     https://courses.ece.ucsb.edu/ECE594/594D_W10Byl/hw/cartpole_eom.pdf
     """
 
-    time_step: float = 0.001
-    state_dim: int = 4
-    observation_dim: int = 4
-    control_dim: int = 1
+    time_step: float = eqx.field(static=True, default=0.001)
+    state_dim: int = eqx.field(static=True, default=4)
+    observation_dim: int = eqx.field(static=True, default=4)
+    control_dim: int = eqx.field(static=True, default=1)
 
     cart_mass: float = 1.0
     pole_mass: float = 0.01
     pole_length: float = 2.0
     gravity: float = 9.81
-    batch_size: int = 1
+    batch_size: int = eqx.field(static=True, default=1)
 
     def __check_init__(self) -> None:
         super().__check_init__()
@@ -66,42 +67,40 @@ class CartPoleSystem(System):
             random_key, shape=(self.batch_size, self.state_dim)
         )
 
-    def process(
-        self,
-        time: float,
-        state: Float[Array, "batch_size state_dim"],  # noqa: F722
-        control: Float[Array, "batch_size control_dim"],  # noqa: F722
-        random_key: PRNGKeyArray,
-    ) -> tuple[float, Float[Array, "batch_size state_dim"]]:  # noqa: F722
-        # RK4
-        half_step = 0.5 * self.time_step
-        k1 = self._df(time, state, control)
-        k2 = self._df(time + half_step, state + half_step * k1, control)
-        k3 = self._df(time + half_step, state + half_step * k2, control)
-        k4 = self._df(
-            time + self.time_step, state + self.time_step * k3, control
-        )
-        process_noise = self._process_noise(time, state, random_key)
-        state = state + self.time_step * (k1 + 2 * k2 + 2 * k3 + k4) / 6
-        state = state + process_noise
-        return (
-            time + self.time_step,
-            state,
-        )
-
     def observe(
         self,
         time: float,
         state: Float[Array, "batch_size state_dim"],  # noqa: F722
         random_key: PRNGKeyArray,
     ) -> Float[Array, "batch_size observation_dim"]:  # noqa: F722
-        return state + self._observation_noise(time, state, random_key)
+        return state
 
-    def _df(
+    def process(
+        self,
+        time: Array,
+        state: Array,
+        random_key: PRNGKeyArray,
+        *,
+        control: Array | None = None,
+    ) -> tuple[Array, Array]:
+        # NOTE: Easy RK4 step impl. Consider diffrax.Tsit5 :)
+        half_step = 0.5 * self.time_step
+        k1 = self.dynamics(time, state, control)
+        k2 = self.dynamics(time + half_step, state + half_step * k1, control)
+        k3 = self.dynamics(time + half_step, state + half_step * k2, control)
+        k4 = self.dynamics(
+            time + self.time_step,
+            state + self.time_step * k3,
+            control,
+        )
+        next_state = state + self.time_step * (k1 + 2 * k2 + 2 * k3 + k4) / 6
+        return time + self.time_step, next_state
+
+    def dynamics(
         self,
         time: float,
         state: Array,
-        control: Array,
+        control: Array | None = None,
     ) -> Float[Array, "batch_size state_dim"]:  # noqa: F722
         """
         Cart-pole physics ODEs
@@ -109,7 +108,6 @@ class CartPoleSystem(System):
         cart_velocity = state[:, 1]
         pole_angle = state[:, 2]
         pole_angular_velocity = state[:, 3]
-        force = control[:, 0]
 
         total_mass = self.cart_mass + self.pole_mass
         total_mass_adjusted = self.cart_mass + (
@@ -117,17 +115,28 @@ class CartPoleSystem(System):
         )
         pole_mass_length = self.pole_mass * self.pole_length
 
-        common_numerator = force + (
+        common_numerator = (
             pole_mass_length * jnp.sin(pole_angle) * pole_angular_velocity**2
         )
-        pole_angular_acceleration = (
+        pole_angular_acceleration_numerator = (
             total_mass * self.gravity * jnp.sin(pole_angle)
-            - force * jnp.cos(pole_angle)
             - pole_mass_length
-            * pole_angular_velocity**2
+            * pole_angular_velocity** 2
             * jnp.sin(pole_angle)
             * jnp.cos(pole_angle)
-        ) / (total_mass_adjusted * self.pole_length)
+        )
+        # This is intended branching: JAX expression saves for no-control
+        if control is not None:
+            force = control[:, 0]
+            common_numerator = common_numerator + force
+            pole_angular_acceleration_numerator = (
+                pole_angular_acceleration_numerator
+                - force * jnp.cos(pole_angle)
+            )
+
+        pole_angular_acceleration = pole_angular_acceleration_numerator / (
+            total_mass_adjusted * self.pole_length
+        )
         cart_acceleration = (
             common_numerator
             - self.pole_mass

--- a/examples/system/cart_pole/cart_pole_system.py
+++ b/examples/system/cart_pole/cart_pole_system.py
@@ -1,0 +1,147 @@
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float, PRNGKeyArray
+
+from ss.system import System
+
+
+class CartPoleSystem(System):
+    """
+    Cart-pole system dynamics.
+
+    The cart-pole system is a classic control problem where a pole is attached
+      to a cart moving along a frictionless track.
+
+    The number of states is 4, with the state vector including position and
+    velocity of the cart, and angle and angular velocity of the pole.
+    The pole is at its upright position when the angle is 0, and the positive
+    direction is counter-clockwise. The number of observations is 4, with the
+    observation vector being the same as the state vector. The number of
+    controls is 1, with the control vector being the force applied to the cart.
+
+    The system is described by the equations from:
+    https://courses.ece.ucsb.edu/ECE594/594D_W10Byl/hw/cartpole_eom.pdf
+    """
+
+    time_step: float = 0.001
+    state_dim: int = 4
+    observation_dim: int = 4
+    control_dim: int = 1
+
+    cart_mass: float = 1.0
+    pole_mass: float = 0.01
+    pole_length: float = 2.0
+    gravity: float = 9.81
+    batch_size: int = 1
+
+    def __check_init__(self) -> None:
+        super().__check_init__()
+        assert self.time_step > 0, "time_step must be > 0"
+        assert self.cart_mass > 0, "cart_mass must be > 0"
+        assert self.pole_mass > 0, "pole_mass must be > 0"
+        assert self.pole_length > 0, "pole_length must be > 0"
+        assert self.gravity >= 0, "gravity must be >= 0"
+        assert self.batch_size > 0, "batch_size must be > 0"
+
+    def init_state(
+        self, random_key: PRNGKeyArray | None = None
+    ) -> Float[Array, "batch_size state_dim"]:  # noqa: F722
+        """
+        Initialize near the unstable upright equilibrium.
+
+        If random_key is provided, add stochasticity
+        """
+        state = jnp.broadcast_to(
+            jnp.array([0.0, 0.0, 0.0, 0.0]),
+            (self.batch_size, self.state_dim),
+        )
+
+        # Stochastic init
+        if random_key is None:
+            return state
+
+        # FIXME: arbitrary for now.
+        standard_deviation = jnp.array([0.05, 0.02, 0.05, 0.02])
+        return state + standard_deviation * jax.random.normal(
+            random_key, shape=(self.batch_size, self.state_dim)
+        )
+
+    def process(
+        self,
+        time: float,
+        state: Float[Array, "batch_size state_dim"],  # noqa: F722
+        control: Float[Array, "batch_size control_dim"],  # noqa: F722
+        random_key: PRNGKeyArray,
+    ) -> tuple[float, Float[Array, "batch_size state_dim"]]:  # noqa: F722
+        # RK4
+        half_step = 0.5 * self.time_step
+        k1 = self._df(time, state, control)
+        k2 = self._df(time + half_step, state + half_step * k1, control)
+        k3 = self._df(time + half_step, state + half_step * k2, control)
+        k4 = self._df(
+            time + self.time_step, state + self.time_step * k3, control
+        )
+        process_noise = self._process_noise(time, state, random_key)
+        state = state + self.time_step * (k1 + 2 * k2 + 2 * k3 + k4) / 6
+        state = state + process_noise
+        return (
+            time + self.time_step,
+            state,
+        )
+
+    def observe(
+        self,
+        time: float,
+        state: Float[Array, "batch_size state_dim"],  # noqa: F722
+        random_key: PRNGKeyArray,
+    ) -> Float[Array, "batch_size observation_dim"]:  # noqa: F722
+        return state + self._observation_noise(time, state, random_key)
+
+    def _df(
+        self,
+        time: float,
+        state: Array,
+        control: Array,
+    ) -> Float[Array, "batch_size state_dim"]:  # noqa: F722
+        """
+        Cart-pole physics ODEs
+        """
+        cart_velocity = state[:, 1]
+        pole_angle = state[:, 2]
+        pole_angular_velocity = state[:, 3]
+        force = control[:, 0]
+
+        total_mass = self.cart_mass + self.pole_mass
+        total_mass_adjusted = self.cart_mass + (
+            self.pole_mass * jnp.sin(pole_angle) ** 2
+        )
+        pole_mass_length = self.pole_mass * self.pole_length
+
+        common_numerator = force + (
+            pole_mass_length * jnp.sin(pole_angle) * pole_angular_velocity**2
+        )
+        pole_angular_acceleration = (
+            total_mass * self.gravity * jnp.sin(pole_angle)
+            - force * jnp.cos(pole_angle)
+            - pole_mass_length
+            * pole_angular_velocity**2
+            * jnp.sin(pole_angle)
+            * jnp.cos(pole_angle)
+        ) / (total_mass_adjusted * self.pole_length)
+        cart_acceleration = (
+            common_numerator
+            - self.pole_mass
+            * self.gravity
+            * jnp.sin(pole_angle)
+            * jnp.cos(pole_angle)
+        ) / total_mass_adjusted
+
+        return jnp.stack(
+            (
+                cart_velocity,
+                cart_acceleration,
+                pole_angular_velocity,
+                pole_angular_acceleration,
+            ),
+            axis=-1,
+        )

--- a/examples/system/cart_pole/post_processing.py
+++ b/examples/system/cart_pole/post_processing.py
@@ -1,0 +1,137 @@
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+from matplotlib.animation import FFMpegWriter, FuncAnimation
+from matplotlib.patches import Circle
+
+import jax.numpy as jnp
+from jaxtyping import Array
+
+
+def plot_simulation(
+    times: Array,
+    states: Array,
+    save_path: Path | None = None,
+) -> None:
+    """Plot one cart-pole trajectory and optionally save the figure."""
+
+    figure, axes = plt.subplots(
+        2, 2, figsize=(11, 7), sharex=True, constrained_layout=True
+    )
+    series = (
+        (0, "Cart position", "Position (m)"),
+        (2, "Pole angle", "Angle (rad)"),
+        (1, "Cart velocity", "Velocity (m/s)"),
+        (3, "Pole angular velocity", "Angular velocity (rad/s)"),
+    )
+    for axis, (state_index, title, ylabel) in zip(
+        axes.flat, series, strict=True
+    ):
+        for batch_index in range(states.shape[1]):
+            axis.plot(
+                times,
+                states[:, batch_index, state_index],
+                linewidth=1.3,
+                alpha=0.8,
+                label=f"Run {batch_index + 1}",
+            )
+        axis.set_title(title)
+        axis.set_ylabel(ylabel)
+        axis.grid(alpha=0.3)
+
+    if states.shape[1] > 1 and states.shape[1] <= 10:
+        axes[0, 0].legend(ncols=2, fontsize="small")
+
+    for axis in axes[-1]:
+        axis.set_xlabel("Time (s)")
+    figure.suptitle("Cart-pole simulation")
+
+    if save_path is not None:
+        figure.savefig(save_path, dpi=160)
+    plt.close(figure)
+    plt.close("all")
+
+
+def render_animation(
+    times: Array,
+    states: Array,
+    pole_length: float,
+    save_path: Path,
+    fps: int = 30,
+) -> None:
+    """Render one cart-pole trajectory as an MP4 animation."""
+
+    num_steps = times.shape[0]
+
+    marker_radius = max(0.08, 0.06 * pole_length)
+    x_positions = states[:, :, 0]
+    horizontal_margin = pole_length + marker_radius
+
+    figure, axis = plt.subplots(figsize=(10, 5), constrained_layout=True)
+    axis.set_xlim(
+        x_positions.min() - horizontal_margin,
+        x_positions.max() + horizontal_margin,
+    )
+    axis.set_ylim(-pole_length - marker_radius, pole_length + marker_radius)
+    axis.set_aspect("equal", adjustable="box")
+    axis.set_xlabel("Horizontal position (m)")
+    axis.set_ylabel("Vertical position (m)")
+    axis.set_title("Cart-pole simulation")
+    axis.grid(alpha=0.25)
+    axis.axhline(0, color="0.3", linewidth=2)
+
+    colors = plt.colormaps["tab10"](
+        jnp.linspace(0, 1, states.shape[1], endpoint=False)
+    )
+    mechanisms = []
+    for batch_index, color in enumerate(colors):
+        cart = Circle(
+            (0, 0),
+            marker_radius,
+            facecolor=color,
+            edgecolor="black",
+            alpha=0.8,
+            zorder=4,
+            label=f"Run {batch_index + 1}",
+        )
+        axis.add_patch(cart)
+        (pole,) = axis.plot([], [], color=color, linewidth=4, zorder=5)
+        bob = Circle((0, 0), marker_radius, color=color, zorder=6)
+        axis.add_patch(bob)
+        mechanisms.append((cart, pole, bob))
+
+    # Commented out legend for large case.
+    # if states.shape[1] > 1 and states.shape[1] <= 10:
+    #     axis.legend(loc="lower right", fontsize="small")
+    time_label = axis.text(0.02, 0.95, "", transform=axis.transAxes)
+
+    def update(frame_index: int):
+        artists = []
+        for batch_index, mechanism in enumerate(mechanisms):
+            # Cart graphics: dumbell - rod connecting two circle
+            cart, pole, bob = mechanism
+            cart_position = states[frame_index, batch_index, 0]
+            pole_angle = states[frame_index, batch_index, 2]
+            pivot_x = cart_position
+            pivot_y = 0
+            bob_x = pivot_x + pole_length * jnp.sin(pole_angle)
+            bob_y = pivot_y + pole_length * jnp.cos(pole_angle)
+
+            cart.center = (cart_position, pivot_y)
+            pole.set_data((pivot_x, bob_x), (pivot_y, bob_y))
+            bob.center = (bob_x, bob_y)
+            artists.extend(mechanism)
+
+        time_label.set_text(f"t = {times[frame_index]:.2f} s")
+        return *artists, time_label
+
+    animation = FuncAnimation(
+        figure,
+        update,
+        frames=num_steps,
+        interval=1000 / fps,
+        blit=True,
+    )
+    writer = FFMpegWriter(fps=fps, metadata={"title": "Cart-pole simulation"})
+    animation.save(save_path, writer=writer, dpi=140)
+    plt.close(figure)

--- a/examples/system/cart_pole/post_processing.py
+++ b/examples/system/cart_pole/post_processing.py
@@ -61,7 +61,10 @@ def render_animation(
 ) -> None:
     """Render one cart-pole trajectory as an MP4 animation."""
 
+    duration = times[-1] - times[0]
     num_steps = times.shape[0]
+    frame_count = min(num_steps, max(2, round(duration * fps)))
+    frame_indices = jnp.linspace(0, num_steps - 1, frame_count, dtype=int)
 
     marker_radius = max(0.08, 0.06 * pole_length)
     x_positions = states[:, :, 0]
@@ -106,12 +109,13 @@ def render_animation(
     time_label = axis.text(0.02, 0.95, "", transform=axis.transAxes)
 
     def update(frame_index: int):
+        state_index = frame_indices[frame_index]
         artists = []
         for batch_index, mechanism in enumerate(mechanisms):
             # Cart graphics: dumbell - rod connecting two circle
             cart, pole, bob = mechanism
-            cart_position = states[frame_index, batch_index, 0]
-            pole_angle = states[frame_index, batch_index, 2]
+            cart_position = states[state_index, batch_index, 0]
+            pole_angle = states[state_index, batch_index, 2]
             pivot_x = cart_position
             pivot_y = 0
             bob_x = pivot_x + pole_length * jnp.sin(pole_angle)
@@ -122,13 +126,13 @@ def render_animation(
             bob.center = (bob_x, bob_y)
             artists.extend(mechanism)
 
-        time_label.set_text(f"t = {times[frame_index]:.2f} s")
+        time_label.set_text(f"t = {times[state_index]:.2f} s")
         return *artists, time_label
 
     animation = FuncAnimation(
         figure,
         update,
-        frames=num_steps,
+        frames=frame_count,
         interval=1000 / fps,
         blit=True,
     )

--- a/examples/system/hidden_markov_model/__main__.py
+++ b/examples/system/hidden_markov_model/__main__.py
@@ -7,7 +7,7 @@ import jax
 import jax.numpy as jnp
 
 from ss.system.discrete import HiddenMarkovModel
-from ss.system import simulate, batch_simulate
+from ss.system import simulate
 
 if __name__ == "__main__":
 
@@ -27,12 +27,12 @@ if __name__ == "__main__":
     )
     print("updated transition_matrix:\n", system.transition_matrix)
 
-    random_key = jax.random.PRNGKey(0)
-
     print("=== single rollout ===")
     time_horizon = 100
 
-    initial_state = jnp.array(0, dtype=jnp.int32)
+    random_key = jax.random.PRNGKey(0)
+
+    initial_state = system.initial_state(random_key)
     random_keys = jax.random.split(random_key, time_horizon)
 
     times, states, observations, _ = simulate(
@@ -46,12 +46,17 @@ if __name__ == "__main__":
 
     print("=== batched rollout ===")
     batch_size = 15
+    systems = system.duplicate(batch_size=batch_size)
 
-    init_states = jnp.tile(jnp.array(0, dtype=jnp.int32), (batch_size, 1))
-    random_keys = jax.random.split(random_key, (batch_size, time_horizon))
 
-    batch_times, batch_states, batch_observations, _ = batch_simulate(
-        system, 0, init_states, random_keys
+    random_key = jax.random.PRNGKey(0)
+    initial_state_key, random_key = jax.random.split(random_key)
+    initial_state_keys = jax.random.split(initial_state_key, batch_size)
+    init_states = systems.initial_state(initial_state_keys)
+    random_keys = jax.random.split(random_key, time_horizon)
+
+    batch_times, batch_states, batch_observations, _ = simulate(
+        systems, 0, init_states, random_keys
     )
 
     print("batch_times shape:", batch_times.shape)

--- a/src/ss/control/__init__.py
+++ b/src/ss/control/__init__.py
@@ -4,9 +4,17 @@ from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ._control import Controller  # noqa: F401
+    from .mppi import (  # noqa: F401
+        MPPIController,
+        MPPIControllerState,
+        MPPIDiagnostics,
+    )
 
 _EXPORTS: dict[str, str] = {
     "Controller": "_control",
+    "MPPIController": "mppi",
+    "MPPIControllerState": "mppi",
+    "MPPIDiagnostics": "mppi",
 }
 
 __all__ = list(_EXPORTS)  # type: ignore[reportUnsupportedDunderAll]

--- a/src/ss/control/__init__.py
+++ b/src/ss/control/__init__.py
@@ -1,0 +1,28 @@
+"""Lazy control re-exports -- see ss/__init__.py for rationale."""
+
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ._control import Controller  # noqa: F401
+
+_EXPORTS: dict[str, str] = {
+    "Controller": "_control",
+}
+
+__all__ = list(_EXPORTS)  # type: ignore[reportUnsupportedDunderAll]
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    module = importlib.import_module(f".{module_name}", __name__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/src/ss/control/_control.py
+++ b/src/ss/control/_control.py
@@ -17,7 +17,7 @@ class Controller(eqx.Module):
         assert self.control_dim > 0, "control_dim must be > 0"
         assert self.batch_size > 0, "batch_size must be > 0"
 
-    def init_state(self, random_key: PRNGKeyArray) -> ControllerState:
+    def init_state(self, random_key: PRNGKeyArray | None = None) -> ControllerState:
         return ()
 
     @abstractmethod

--- a/src/ss/control/_control.py
+++ b/src/ss/control/_control.py
@@ -1,0 +1,28 @@
+from abc import abstractmethod
+
+import equinox as eqx
+from jaxtyping import Array, PRNGKeyArray
+
+
+class Controller(eqx.Module):
+    """Base class for batched stateful controllers."""
+
+    control_dim: int = eqx.field(static=True)
+    batch_size: int = eqx.field(static=True)
+
+    def __check_init__(self) -> None:
+        assert self.control_dim > 0, "control_dim must be > 0"
+        assert self.batch_size > 0, "batch_size must be > 0"
+
+    def init_state(self):
+        return ()
+
+    @abstractmethod
+    def __call__(
+        self,
+        controller_state,
+        time: Array,
+        observation: Array,
+        random_key: PRNGKeyArray,
+    ):
+        raise NotImplementedError

--- a/src/ss/control/_control.py
+++ b/src/ss/control/_control.py
@@ -17,7 +17,7 @@ class Controller(eqx.Module):
         assert self.control_dim > 0, "control_dim must be > 0"
         assert self.batch_size > 0, "batch_size must be > 0"
 
-    def init_state(self) -> ControllerState:
+    def init_state(self, random_key: PRNGKeyArray) -> ControllerState:
         return ()
 
     @abstractmethod

--- a/src/ss/control/_control.py
+++ b/src/ss/control/_control.py
@@ -1,7 +1,10 @@
 from abc import abstractmethod
 
 import equinox as eqx
-from jaxtyping import Array, PRNGKeyArray
+from jaxtyping import Array, Float, PRNGKeyArray, PyTree
+
+type ControllerState = PyTree[Array]
+type Diagnostics = PyTree[Array]
 
 
 class Controller(eqx.Module):
@@ -14,15 +17,19 @@ class Controller(eqx.Module):
         assert self.control_dim > 0, "control_dim must be > 0"
         assert self.batch_size > 0, "batch_size must be > 0"
 
-    def init_state(self):
+    def init_state(self) -> ControllerState:
         return ()
 
     @abstractmethod
     def __call__(
         self,
-        controller_state,
-        time: Array,
-        observation: Array,
+        controller_state: ControllerState,
+        time: Float[Array, ""],
+        observation: Float[Array, "batch_size observation_dim"],
         random_key: PRNGKeyArray,
-    ):
+    ) -> tuple[
+        Float[Array, "batch_size control_dim"],
+        ControllerState,
+        Diagnostics,
+    ]:
         raise NotImplementedError

--- a/src/ss/control/mppi.py
+++ b/src/ss/control/mppi.py
@@ -1,0 +1,166 @@
+# ruff: noqa: F722, F821
+
+from collections.abc import Callable
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float, PRNGKeyArray
+
+from ss.system import System
+
+from ._control import Controller
+
+type RolloutCarry = tuple[
+    Float[Array, "batch_size num_samples"],  # times
+    Float[Array, "batch_size num_samples state_dim"],  # states
+    Float[Array, "batch_size num_samples"],  # accumulated costs
+]
+type RolloutInputs = tuple[
+    Float[Array, "batch_size num_samples control_dim"],  # controls
+    PRNGKeyArray,  # random key
+]
+
+
+class MPPIControllerState(eqx.Module):
+    nominal_controls: Float[Array, "batch_size horizon control_dim"]  # noqa: F722
+
+
+class MPPIDiagnostics(eqx.Module):
+    minimum_rollout_cost: Float[Array, "batch_size"]
+    mean_rollout_cost: Float[Array, "batch_size"]
+
+
+class MPPIController(Controller):
+    """Model Predictive Path Integral controller."""
+
+    rollout_system: System
+
+    running_cost: Callable[
+        [
+            Float[Array, "num_samples state_dim"],  # state
+            Float[Array, "num_samples control_dim"],  # control
+        ],
+        Float[Array, "num_samples"],  # cost
+    ] = eqx.field(static=True)
+    terminal_cost: Callable[
+        [Float[Array, "num_samples state_dim"]],  # state
+        Float[Array, "num_samples"],  # cost
+    ] = eqx.field(static=True)
+
+    horizon: int = eqx.field(static=True, default=60)
+    num_samples: int = eqx.field(static=True, default=1024)
+    temperature: float = eqx.field(static=True, default=2.0)
+    noise_sigma: float = eqx.field(static=True, default=10.0)
+    control_limit: float = eqx.field(static=True, default=40.0)
+
+    def __check_init__(self) -> None:
+        super().__check_init__()
+        object.__setattr__(
+            self,
+            "rollout_system",
+            self.rollout_system.duplicate(batch_size=self.num_samples),
+        )
+        assert self.rollout_system.control_dim == self.control_dim
+        assert self.horizon > 0
+        assert self.num_samples > 0
+        assert self.temperature > 0
+        assert self.noise_sigma > 0
+        assert self.control_limit > 0
+
+    def init_state(self) -> MPPIControllerState:
+        return MPPIControllerState(
+            jnp.zeros((self.batch_size, self.horizon, self.control_dim))
+        )
+
+    def __call__(
+        self,
+        controller_state: MPPIControllerState,
+        time: Float[Array, ""],
+        observation: Float[Array, "batch_size observation_dim"],
+        random_key: PRNGKeyArray,
+    ) -> tuple[
+        Float[Array, "batch_size control_dim"],  # control
+        MPPIControllerState,  # next controller state
+        MPPIDiagnostics,  # diagnostics
+    ]:
+        noise_key, rollout_key = jax.random.split(random_key)
+        noise = self.noise_sigma * jax.random.normal(
+            noise_key,
+            (
+                self.horizon,
+                self.batch_size,
+                self.num_samples,
+                self.control_dim,
+            ),
+        )
+
+        nominal_controls = jnp.swapaxes(  # scan need time-axis in the front
+            controller_state.nominal_controls, 0, 1
+        )
+        sampled_controls = jnp.clip(
+            nominal_controls[:, :, None, :] + noise,
+            -self.control_limit,
+            self.control_limit,
+        )
+        rollout_states = jnp.broadcast_to(
+            observation[:, None, :],
+            (
+                self.batch_size,
+                self.num_samples,
+                observation.shape[-1],
+            ),
+        )
+        rollout_times = jnp.full((self.batch_size, self.num_samples), time)
+        rollout_keys = jax.random.split(
+            rollout_key,
+            (self.horizon, self.batch_size, self.num_samples),
+        )
+
+        def rollout_step(
+            carry: RolloutCarry,
+            inputs: RolloutInputs,
+        ) -> tuple[RolloutCarry, None]:
+            times, states, total_cost = carry
+            controls, process_keys = inputs
+            next_times, next_states = jax.vmap(self.rollout_system.process)(
+                times,
+                states,
+                process_keys,
+                control=controls,
+            )
+            total_cost += self.rollout_system.time_step * jax.vmap(
+                self.running_cost
+            )(next_states, controls)
+            return (next_times, next_states, total_cost), None
+
+        (_, final_states, costs), _ = jax.lax.scan(
+            rollout_step,
+            (
+                rollout_times,
+                rollout_states,
+                jnp.zeros((self.batch_size, self.num_samples)),
+            ),
+            (sampled_controls, rollout_keys),
+        )
+        costs += jax.vmap(self.terminal_cost)(final_states)
+        minimum_cost = jnp.min(costs, axis=-1)
+        mean_cost = jnp.mean(costs, axis=-1)
+        weights = jax.nn.softmax(
+            -(costs - minimum_cost[:, None]) / self.temperature,
+            axis=-1,
+        )
+        update = jnp.einsum("bs,hbsi->hbi", weights, noise)
+        controls = jnp.clip(
+            nominal_controls + update,
+            -self.control_limit,
+            self.control_limit,
+        )
+        shifted = jnp.concatenate(
+            (controls[1:], jnp.zeros_like(controls[:1])), axis=0
+        )
+        return (
+            controls[0],
+            MPPIControllerState(jnp.swapaxes(shifted, 0, 1)),
+            MPPIDiagnostics(minimum_cost, mean_cost),
+        )

--- a/src/ss/control/mppi.py
+++ b/src/ss/control/mppi.py
@@ -68,7 +68,7 @@ class MPPIController(Controller):
         assert self.noise_sigma > 0
         assert self.control_limit > 0
 
-    def init_state(self) -> MPPIControllerState:
+    def init_state(self, random_key: PRNGKeyArray | None = None) -> MPPIControllerState:
         return MPPIControllerState(
             jnp.zeros((self.batch_size, self.horizon, self.control_dim))
         )
@@ -126,8 +126,8 @@ class MPPIController(Controller):
             next_times, next_states = jax.vmap(self.rollout_system.process)(
                 times,
                 states,
+                controls,
                 process_keys,
-                control=controls,
             )
             total_cost += self.rollout_system.time_step * jax.vmap(
                 self.running_cost

--- a/src/ss/system/__init__.py
+++ b/src/ss/system/__init__.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
         simulate,
         batch_simulate,
     )
+    from .cart_pole import CartPoleSystem
     # from .discrete import HiddenMarkovModel
     # from .linear import (
     #     ContinuousTimeLinearSystem,
@@ -27,6 +28,7 @@ _EXPORTS: dict[str, str] = {
     "simulate_step": "_system",
     "simulate": "_system",
     "batch_simulate": "_system",
+    "CartPoleSystem": "cart_pole",
     # "HiddenMarkovModel": "discrete",
     # "ContinuousTimeLinearSystem": "linear",
     # "DiscreteTimeLinearSystem": "linear",
@@ -34,7 +36,7 @@ _EXPORTS: dict[str, str] = {
     # "DiscreteTimeNonlinearSystem": "nonlinear",
 }
 
-__all__ = list(_EXPORTS) # type: ignore[reportUnsupportedDunderAll]
+__all__ = list(_EXPORTS)  # type: ignore[reportUnsupportedDunderAll]
 
 
 def __getattr__(name: str) -> Any:

--- a/src/ss/system/__init__.py
+++ b/src/ss/system/__init__.py
@@ -1,4 +1,5 @@
 """Lazy re-exports -- see ss/__init__.py for rationale."""
+
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -6,9 +7,7 @@ if TYPE_CHECKING:
         ContinuousTimeSystem,
         DiscreteTimeSystem,
         System,
-        simulate_step,
         simulate,
-        batch_simulate,
     )
     from .cart_pole import CartPoleSystem
     # from .discrete import HiddenMarkovModel
@@ -25,9 +24,7 @@ _EXPORTS: dict[str, str] = {
     "ContinuousTimeSystem": "_system",
     "DiscreteTimeSystem": "_system",
     "System": "_system",
-    "simulate_step": "_system",
     "simulate": "_system",
-    "batch_simulate": "_system",
     "CartPoleSystem": "cart_pole",
     # "HiddenMarkovModel": "discrete",
     # "ContinuousTimeLinearSystem": "linear",

--- a/src/ss/system/_system.py
+++ b/src/ss/system/_system.py
@@ -40,7 +40,7 @@ class System(eqx.Module):
         object.__setattr__(duplicate, "batch_size", batch_size)
         return duplicate
 
-    def init_state(
+    def initial_state(
         self, random_key: PRNGKeyArray | None = None
     ) -> Float[Array, state_dim]:
         return jnp.zeros(self.state_dim)

--- a/src/ss/system/_system.py
+++ b/src/ss/system/_system.py
@@ -48,44 +48,52 @@ class System(eqx.Module):
     def process(
         self,
         time: float,
-        state: Float[Array, "state_dim"],
-        control: Float[Array, "control_dim"],
+        state: Float[Array, state_dim],
+        control: Float[Array, control_dim],
         random_key: PRNGKeyArray,
-    ) -> tuple[float, Float[Array, "state_dim"]]:
+    ) -> tuple[float, Float[Array, state_dim]]:
         return (
             time + self.time_step,
-            self._state_process(time, state, control) + self._process_noise(time, state, random_key)
+            self._state_process(time, state, control)
+            + self._process_noise(time, state, random_key),
         )
 
     def observe(
         self,
         time: float,
-        state: Float[Array, "state_dim"],
+        state: Float[Array, state_dim],
         random_key: PRNGKeyArray,
-    ) -> Float[Array, "observation_dim"]:
-        return self._observation_process(time, state) + self._observation_noise(
-            time, state, random_key
-        )
+    ) -> Float[Array, observation_dim]:
+        return self._observation_process(
+            time, state
+        ) + self._observation_noise(time, state, random_key)
 
     def _state_process(
         self, time: float, state: Array, control: Array
-    ) -> Float[Array, "state_dim"]:
+    ) -> Float[Array, state_dim]:
         return state
 
-    def _observation_process(self, time: float, state: Array) -> Float[Array, "observation_dim"]:
+    def _observation_process(
+        self, time: float, state: Array
+    ) -> Float[Array, observation_dim]:
         return jnp.zeros(self.observation_dim)
 
-    def _process_noise(self, time: float, state: Array, random_key: PRNGKeyArray) -> Array:
+    def _process_noise(
+        self, time: float, state: Array, random_key: PRNGKeyArray
+    ) -> Array:
         return jnp.zeros(self.state_dim)
 
-    def _observation_noise(self, time: float, state: Array, random_key: PRNGKeyArray) -> Array:
+    def _observation_noise(
+        self, time: float, state: Array, random_key: PRNGKeyArray
+    ) -> Array:
         return jnp.zeros(self.observation_dim)
 
 
 class ContinuousTimeSystem(System):
-
-    process_noise_covariance: Float[Array, "state_dim state_dim"]
-    observation_noise_covariance: Float[Array, "observation_dim observation_dim"]
+    process_noise_covariance: Float[Array, state_dim state_dim]
+    observation_noise_covariance: Float[
+        Array, observation_dim observation_dim
+    ]
 
     def __check_init__(self) -> None:
         super().__check_init__()
@@ -100,7 +108,9 @@ class ContinuousTimeSystem(System):
             f"{self.observation_noise_covariance.shape}"
         )
 
-    def _process_noise(self, time: float, state: Array, random_key: PRNGKeyArray) -> Array:
+    def _process_noise(
+        self, time: float, state: Array, random_key: PRNGKeyArray
+    ) -> Array:
         cov = self.process_noise_covariance * jnp.sqrt(self.time_step)
         # multivariate_normal requires positive-definite covariance; when
         # covariance is identically zero (no noise requested) skip sampling
@@ -108,22 +118,30 @@ class ContinuousTimeSystem(System):
         return jax.lax.cond(
             jnp.all(cov == 0),
             lambda: jnp.zeros(self.state_dim),
-            lambda: jax.random.multivariate_normal(random_key, jnp.zeros(self.state_dim), cov),
+            lambda: jax.random.multivariate_normal(
+                random_key, jnp.zeros(self.state_dim), cov
+            ),
         )
 
-    def _observation_noise(self, time: float, state: Array, random_key: PRNGKeyArray) -> Array:
+    def _observation_noise(
+        self, time: float, state: Array, random_key: PRNGKeyArray
+    ) -> Array:
         cov = self.observation_noise_covariance * jnp.sqrt(self.time_step)
         return jax.lax.cond(
             jnp.all(cov == 0),
             lambda: jnp.zeros(self.observation_dim),
-            lambda: jax.random.multivariate_normal(random_key, jnp.zeros(self.observation_dim), cov),
+            lambda: jax.random.multivariate_normal(
+                random_key, jnp.zeros(self.observation_dim), cov
+            ),
         )
 
 
 class DiscreteTimeSystem(ContinuousTimeSystem):
     def __check_init__(self) -> None:
         super().__check_init__()
-        assert self.time_step == 1, "DiscreteTimeSystem requires time_step == 1"
+        assert self.time_step == 1, (
+            "DiscreteTimeSystem requires time_step == 1"
+        )
 
 
 SystemT = TypeVar("SystemT", bound=System)
@@ -143,6 +161,7 @@ def simulate(
     else:
         controller_state = None
 
+    @jax.jit
     def body(
         carry: tuple[
             Float,  # time
@@ -162,20 +181,16 @@ def simulate(
         process_keys = step_keys[system.batch_size : 2 * system.batch_size]
         controller_key = step_keys[-1]
 
-        observation = jax.vmap(
-            lambda state, key: system.observe(previous_time, state, key)
-        )(previous_state, observe_keys)
+        observation = system.observe(
+            previous_time, previous_state, observe_keys
+        )
 
         if controller is None:
             control = None
             next_controller_state = None
-            next_times, state = jax.vmap(
-                lambda x, key: system.process(
-                    time=previous_time,
-                    state=x,
-                    random_key=key,
-                )
-            )(previous_state, process_keys)
+            next_time, state = system.process(
+                previous_time, previous_state, process_keys
+            )
         else:
             control, next_controller_state, _ = controller(
                 controller_state,
@@ -183,24 +198,18 @@ def simulate(
                 observation,
                 controller_key,
             )
-            next_times, state = jax.vmap(
-                lambda x, u, key: system.process(
-                    time=previous_time,
-                    state=x,
-                    control=u,
-                    random_key=key,
-                )
-            )(previous_state, control, process_keys)
+            next_time, state = system.process(
+                previous_time, previous_state, process_keys, control=control
+            )
 
-        time = next_times[0]
         return (
-            time,
+            next_time,
             state,
             next_controller_state,
-        ), (time, state, observation, control)
+        ), (next_time, state, observation, control)
 
     _, (times, states, observations, controls) = jax.lax.scan(
-        jax.jit(body),  # NOTE: Slightly debatable if jit layer is needed.
+        body,
         (initial_time, initial_state, controller_state),
         keys,
     )

--- a/src/ss/system/_system.py
+++ b/src/ss/system/_system.py
@@ -117,39 +117,47 @@ class DiscreteTimeSystem(ContinuousTimeSystem):
 SystemT = TypeVar("SystemT", bound=System)
 
 
-def simulate_step(
-    system: SystemT,
-    control_policy: Callable[[Float, Array], Array],
-    carry: tuple[Float, Array],
-    random_key: PRNGKeyArray,
-) -> tuple[tuple[Float, Array], tuple[Float, Array, Array, Array]]:
-
-    previous_time, previous_state = carry
-    process_key, observe_key = jax.random.split(random_key, 2)
-
-    observation = system.observe(previous_time, previous_state, observe_key)
-    control = control_policy(previous_time, observation)
-    time, state = system.process(
-        time=previous_time,
-        state=previous_state,
-        control=control,
-        random_key=process_key,
-    )
-    return (time, state), (time, state, observation, control)
-
 def simulate(
     system: SystemT,
     initial_time: Float,
     initial_state: Array,
     keys: PRNGKeyArray,
-    control_policy: Callable[[Float, Array], Array] = lambda time, observation: jnp.zeros((1,)),
-) -> tuple[Array, Array, Array, Array]:
+    control_policy: Callable[[Float, Array], Array] | None = None,
+) -> tuple[Array, Array, Array, Array | None]:
     """
-    Simulate a system over a time horizon, given an initial state and a sequence of random keys.
-    The control policy is a function that takes the current time and observation and returns the control input.
+    Simulate from an initial state using a sequence of random keys.
+
+    The control policy receives the current time and observation and returns
+    the control input.
+    Pass ``control_policy=None`` to use a system's uncontrolled process path.
     """
 
-    body = partial(simulate_step, system, control_policy)
+    def body(
+        carry: tuple[Float, Array],
+        random_key: PRNGKeyArray,
+    ) -> tuple[tuple[Float, Array], tuple[Float, Array, Array, Array | None]]:
+        previous_time, previous_state = carry
+        process_key, observe_key = jax.random.split(random_key, 2)
+
+        observation = system.observe(
+            previous_time, previous_state, observe_key
+        )
+        if control_policy is None:
+            control = None
+            time, state = system.process(
+                time=previous_time,
+                state=previous_state,
+                random_key=process_key,
+            )
+        else:
+            control = control_policy(previous_time, observation)
+            time, state = system.process(
+                time=previous_time,
+                state=previous_state,
+                control=control,
+                random_key=process_key,
+            )
+        return (time, state), (time, state, observation, control)
 
     _, (times, states, observations, controls) = jax.lax.scan(
         body, (initial_time, initial_state), keys
@@ -169,11 +177,13 @@ def batch_simulate(
     initial_time: Float,
     initial_states: Array,  # (batch, state_dim,)
     keys: PRNGKeyArray,  # (batch, num_steps,)
-    control_policy: Callable[[Float, Array], Array] = lambda time, observation: jnp.zeros((1,)),
+    control_policy: Callable[[Float, Array], Array] = None,
 ) -> tuple[Array, Array, Array, Array]:
     """
-    Simulate a batch of systems over a time horizon, given initial states and a batch of random keys.
-    The control policy is a function that takes the current time and observation and returns the control input.
+    Simulate a batch of systems from the supplied initial states.
+
+    The control policy receives the current time and observation and returns
+    the control input.
     """
     _batch_simulate = jax.vmap(simulate, in_axes=(None, None, 0, 0, None))
     return _batch_simulate(

--- a/src/ss/system/_system.py
+++ b/src/ss/system/_system.py
@@ -49,7 +49,7 @@ class System(eqx.Module):
         self,
         time: float,
         state: Float[Array, state_dim],
-        control: Float[Array, control_dim],
+        control: Float[Array, control_dim] | None,
         random_key: PRNGKeyArray,
     ) -> tuple[float, Float[Array, state_dim]]:
         return (
@@ -69,7 +69,7 @@ class System(eqx.Module):
         ) + self._observation_noise(time, state, random_key)
 
     def _state_process(
-        self, time: float, state: Array, control: Array
+        self, time: float, state: Array, control: Array | None
     ) -> Float[Array, state_dim]:
         return state
 
@@ -156,8 +156,12 @@ def simulate(
 ) -> tuple[Array, Array, Array, Array | None]:
     """Simulate batches with a time scan containing vmapped system steps."""
     if controller is not None:
-        assert system.batch_size == controller.batch_size  # TODO: message
-        controller_state = controller.init_state()  # TODO: key?
+        assert system.batch_size == controller.batch_size, (
+            f"system.batch_size {system.batch_size} must match "
+            f"controller.batch_size {controller.batch_size}"
+        )
+        keys, controller_key = jax.random.split(keys, 2)
+        controller_state = controller.init_state(controller_key)
     else:
         controller_state = None
 
@@ -189,7 +193,7 @@ def simulate(
             control = None
             next_controller_state = None
             next_time, state = system.process(
-                previous_time, previous_state, process_keys
+                previous_time, previous_state, control, process_keys
             )
         else:
             control, next_controller_state, _ = controller(
@@ -199,7 +203,7 @@ def simulate(
                 controller_key,
             )
             next_time, state = system.process(
-                previous_time, previous_state, process_keys, control=control
+                previous_time, previous_state, control, process_keys,
             )
 
         return (

--- a/src/ss/system/_system.py
+++ b/src/ss/system/_system.py
@@ -28,7 +28,9 @@ class System(eqx.Module):
             f"control_dim {self.control_dim} must be >= 0"
         )
 
-    def init_state(self) -> Float[Array, "state_dim"]:
+    def init_state(
+        self, random_key: PRNGKeyArray | None = None
+    ) -> Float[Array, state_dim]:
         return jnp.zeros(self.state_dim)
 
     def process(

--- a/src/ss/system/_system.py
+++ b/src/ss/system/_system.py
@@ -150,7 +150,7 @@ def simulate(
             ControllerState | None,  # controller state
         ],
         random_key: PRNGKeyArray,
-    ) -> tuple[  # NOTE: Not exactly sure why this structure is necessary
+    ) -> tuple[
         tuple[Float, Array, ControllerState | None],
         tuple[Float, Array, Array, Array | None],
     ]:

--- a/src/ss/system/_system.py
+++ b/src/ss/system/_system.py
@@ -1,18 +1,19 @@
-"""
-A dynamical system framework for simulating continuous and discrete time systems.
-"""
+"""Framework for simulating continuous and discrete-time systems."""
+
 from __future__ import annotations
 
-from typing import Callable, TypeVar
-from functools import partial
+from typing import TYPE_CHECKING, TypeVar
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array, Float, PRNGKeyArray
+from jaxtyping import Array, Float, PRNGKeyArray, PyTree
+
+if TYPE_CHECKING:
+    from ss.control._control import Controller
 
 
 class System(eqx.Module):
-
     time_step: float = eqx.field(static=True)
     state_dim: int = eqx.field(static=True)
     observation_dim: int = eqx.field(static=True)
@@ -122,70 +123,75 @@ def simulate(
     initial_time: Float,
     initial_state: Array,
     keys: PRNGKeyArray,
-    control_policy: Callable[[Float, Array], Array] | None = None,
+    controller: Controller | None = None,
 ) -> tuple[Array, Array, Array, Array | None]:
-    """
-    Simulate from an initial state using a sequence of random keys.
-
-    The control policy receives the current time and observation and returns
-    the control input.
-    Pass ``control_policy=None`` to use a system's uncontrolled process path.
-    """
+    """Simulate batches with a time scan containing vmapped system steps."""
+    if controller is not None:
+        assert system.batch_size == controller.batch_size  # TODO: message
+        controller_state = controller.init_state()  # TODO: key?
+    else:
+        controller_state = None
 
     def body(
-        carry: tuple[Float, Array],
+        carry: tuple[
+            Float,  # time
+            Array,  # system state
+            PyTree[Array] | None,  # control state
+        ],
         random_key: PRNGKeyArray,
-    ) -> tuple[tuple[Float, Array], tuple[Float, Array, Array, Array | None]]:
-        previous_time, previous_state = carry
-        process_key, observe_key = jax.random.split(random_key, 2)
+    ) -> tuple[  # NOTE: Not exactly sure why this structure is necessary
+        tuple[Float, Array, PyTree[Array]],
+        tuple[Float, Array, Array, Array | None],
+    ]:
+        previous_time, previous_state, controller_state = carry
 
-        observation = system.observe(
-            previous_time, previous_state, observe_key
-        )
-        if control_policy is None:
+        # Key splits
+        step_keys = jax.random.split(random_key, 2 * system.batch_size + 1)
+        observe_keys = step_keys[: system.batch_size]
+        process_keys = step_keys[system.batch_size : 2 * system.batch_size]
+        controller_key = step_keys[-1]
+
+        observation = jax.vmap(
+            lambda state, key: system.observe(previous_time, state, key)
+        )(previous_state, observe_keys)
+
+        if controller is None:
             control = None
-            time, state = system.process(
-                time=previous_time,
-                state=previous_state,
-                random_key=process_key,
-            )
+            next_controller_state = None
+            next_times, state = jax.vmap(
+                lambda x, key: system.process(
+                    time=previous_time,
+                    state=x,
+                    random_key=key,
+                )
+            )(previous_state, process_keys)
         else:
-            control = control_policy(previous_time, observation)
-            time, state = system.process(
-                time=previous_time,
-                state=previous_state,
-                control=control,
-                random_key=process_key,
+            control, next_controller_state, _ = controller(
+                controller_state,
+                previous_time,
+                observation,
+                controller_key,
             )
-        return (time, state), (time, state, observation, control)
+            next_times, state = jax.vmap(
+                lambda x, u, key: system.process(
+                    time=previous_time,
+                    state=x,
+                    control=u,
+                    random_key=key,
+                )
+            )(previous_state, control, process_keys)
+
+        time = next_times[0]
+        return (
+            time,
+            state,
+            next_controller_state,
+        ), (time, state, observation, control)
 
     _, (times, states, observations, controls) = jax.lax.scan(
-        body, (initial_time, initial_state), keys
+        jax.jit(body),  # NOTE: Slightly debatable if jit layer is needed.
+        (initial_time, initial_state, controller_state),
+        keys,
     )
-
-    if states.ndim == 1:
-        states = states[:, jnp.newaxis]
-
-    if observations.ndim == 1:
-        observations = observations[:, jnp.newaxis]
 
     return times, states, observations, controls
-
-
-def batch_simulate(
-    system: SystemT,
-    initial_time: Float,
-    initial_states: Array,  # (batch, state_dim,)
-    keys: PRNGKeyArray,  # (batch, num_steps,)
-    control_policy: Callable[[Float, Array], Array] = None,
-) -> tuple[Array, Array, Array, Array]:
-    """
-    Simulate a batch of systems from the supplied initial states.
-
-    The control policy receives the current time and observation and returns
-    the control input.
-    """
-    _batch_simulate = jax.vmap(simulate, in_axes=(None, None, 0, 0, None))
-    return _batch_simulate(
-        system, initial_time, initial_states, keys, control_policy
-    )

--- a/src/ss/system/_system.py
+++ b/src/ss/system/_system.py
@@ -7,10 +7,10 @@ from typing import TYPE_CHECKING, TypeVar
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array, Float, PRNGKeyArray, PyTree
+from jaxtyping import Array, Float, PRNGKeyArray
 
 if TYPE_CHECKING:
-    from ss.control._control import Controller
+    from ss.control._control import Controller, ControllerState
 
 
 class System(eqx.Module):
@@ -136,11 +136,11 @@ def simulate(
         carry: tuple[
             Float,  # time
             Array,  # system state
-            PyTree[Array] | None,  # control state
+            ControllerState | None,  # controller state
         ],
         random_key: PRNGKeyArray,
     ) -> tuple[  # NOTE: Not exactly sure why this structure is necessary
-        tuple[Float, Array, PyTree[Array]],
+        tuple[Float, Array, ControllerState | None],
         tuple[Float, Array, Array, Array | None],
     ]:
         previous_time, previous_state, controller_state = carry

--- a/src/ss/system/_system.py
+++ b/src/ss/system/_system.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, TypeVar, Self
 
 from copy import copy
 
@@ -90,9 +90,9 @@ class System(eqx.Module):
 
 
 class ContinuousTimeSystem(System):
-    process_noise_covariance: Float[Array, state_dim state_dim]
+    process_noise_covariance: Float[Array, "state_dim state_dim"]
     observation_noise_covariance: Float[
-        Array, observation_dim observation_dim
+        Array, "observation_dim observation_dim"
     ]
 
     def __check_init__(self) -> None:

--- a/src/ss/system/_system.py
+++ b/src/ss/system/_system.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypeVar
 
+from copy import copy
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -18,6 +20,7 @@ class System(eqx.Module):
     state_dim: int = eqx.field(static=True)
     observation_dim: int = eqx.field(static=True)
     control_dim: int = eqx.field(static=True)
+    batch_size: int = eqx.field(static=True)
 
     def __check_init__(self) -> None:
         assert self.time_step >= 0, f"time_step {self.time_step} must be >= 0"
@@ -28,6 +31,14 @@ class System(eqx.Module):
         assert self.control_dim >= 0, (
             f"control_dim {self.control_dim} must be >= 0"
         )
+        assert self.batch_size > 0, f"batch_size {self.batch_size} must be > 0"
+
+    def duplicate(self, *, batch_size: int) -> Self:
+        """Return an immutable copy configured for a new batch size."""
+        assert batch_size > 0, f"batch_size {batch_size} must be > 0"
+        duplicate = copy(self)
+        object.__setattr__(duplicate, "batch_size", batch_size)
+        return duplicate
 
     def init_state(
         self, random_key: PRNGKeyArray | None = None

--- a/src/ss/system/_system.py
+++ b/src/ss/system/_system.py
@@ -153,6 +153,7 @@ def simulate(
     initial_state: Array,
     keys: PRNGKeyArray,
     controller: Controller | None = None,
+    initial_key: PRNGKeyArray | None = None,
 ) -> tuple[Array, Array, Array, Array | None]:
     """Simulate batches with a time scan containing vmapped system steps."""
     if controller is not None:
@@ -160,8 +161,7 @@ def simulate(
             f"system.batch_size {system.batch_size} must match "
             f"controller.batch_size {controller.batch_size}"
         )
-        keys, controller_key = jax.random.split(keys, 2)
-        controller_state = controller.init_state(controller_key)
+        controller_state = controller.init_state(initial_key)
     else:
         controller_state = None
 

--- a/src/ss/system/cart_pole.py
+++ b/src/ss/system/cart_pole.py
@@ -57,9 +57,8 @@ class CartPoleSystem(System):
         self,
         time: Float,
         state: Array,
+        control: Array | None,
         random_key: PRNGKeyArray,
-        *,
-        control: Array | None = None,
     ) -> tuple[Array, Array]:
         half_step = 0.5 * self.time_step
         k1 = self.dynamics(time, state, control)

--- a/src/ss/system/cart_pole.py
+++ b/src/ss/system/cart_pole.py
@@ -47,7 +47,7 @@ class CartPoleSystem(System):
 
     def observe(
         self,
-        time: float,
+        time: Float,
         state: Float[Array, "state_dim"],
         random_key: PRNGKeyArray,
     ) -> Float[Array, "observation_dim"]:
@@ -55,7 +55,7 @@ class CartPoleSystem(System):
 
     def process(
         self,
-        time: Array,
+        time: Float,
         state: Array,
         random_key: PRNGKeyArray,
         *,

--- a/src/ss/system/cart_pole.py
+++ b/src/ss/system/cart_pole.py
@@ -29,7 +29,7 @@ class CartPoleSystem(System):
         assert self.gravity >= 0, "gravity must be >= 0"
         assert self.batch_size > 0, "batch_size must be > 0"
 
-    def init_state(
+    def initial_state(
         self, random_key: PRNGKeyArray | None = None
     ) -> Float[Array, "batch_size state_dim"]:  # noqa: F722
         """Initialize near the unstable upright equilibrium."""

--- a/src/ss/system/cart_pole.py
+++ b/src/ss/system/cart_pole.py
@@ -1,28 +1,13 @@
+import equinox as eqx
 import jax
 import jax.numpy as jnp
-import equinox as eqx
 from jaxtyping import Array, Float, PRNGKeyArray
 
-from ss.system import System
+from ._system import System
 
 
 class CartPoleSystem(System):
-    """
-    Cart-pole system dynamics.
-
-    The cart-pole system is a classic control problem where a pole is attached
-      to a cart moving along a frictionless track.
-
-    The number of states is 4, with the state vector including position and
-    velocity of the cart, and angle and angular velocity of the pole.
-    The pole is at its upright position when the angle is 0, and the positive
-    direction is counter-clockwise. The number of observations is 4, with the
-    observation vector being the same as the state vector. The number of
-    controls is 1, with the control vector being the force applied to the cart.
-
-    The system is described by the equations from:
-    https://courses.ece.ucsb.edu/ECE594/594D_W10Byl/hw/cartpole_eom.pdf
-    """
+    """Batched cart-pole dynamics with an RK4 integration step."""
 
     time_step: float = eqx.field(static=True, default=0.001)
     state_dim: int = eqx.field(static=True, default=4)
@@ -47,21 +32,14 @@ class CartPoleSystem(System):
     def init_state(
         self, random_key: PRNGKeyArray | None = None
     ) -> Float[Array, "batch_size state_dim"]:  # noqa: F722
-        """
-        Initialize near the unstable upright equilibrium.
-
-        If random_key is provided, add stochasticity
-        """
+        """Initialize near the unstable upright equilibrium."""
         state = jnp.broadcast_to(
-            jnp.array([0.0, 0.0, 0.0, 0.0]),
+            jnp.zeros(self.state_dim),
             (self.batch_size, self.state_dim),
         )
-
-        # Stochastic init
         if random_key is None:
             return state
 
-        # FIXME: arbitrary for now.
         standard_deviation = jnp.array([0.05, 0.02, 0.05, 0.02])
         return state + standard_deviation * jax.random.normal(
             random_key, shape=(self.batch_size, self.state_dim)
@@ -70,9 +48,9 @@ class CartPoleSystem(System):
     def observe(
         self,
         time: float,
-        state: Float[Array, "batch_size state_dim"],  # noqa: F722
+        state: Float[Array, "state_dim"],
         random_key: PRNGKeyArray,
-    ) -> Float[Array, "batch_size observation_dim"]:  # noqa: F722
+    ) -> Float[Array, "observation_dim"]:
         return state
 
     def process(
@@ -83,7 +61,6 @@ class CartPoleSystem(System):
         *,
         control: Array | None = None,
     ) -> tuple[Array, Array]:
-        # NOTE: Easy RK4 step impl. Consider diffrax.Tsit5 :)
         half_step = 0.5 * self.time_step
         k1 = self.dynamics(time, state, control)
         k2 = self.dynamics(time + half_step, state + half_step * k1, control)
@@ -101,16 +78,16 @@ class CartPoleSystem(System):
         time: float,
         state: Array,
         control: Array | None = None,
-    ) -> Float[Array, "batch_size state_dim"]:  # noqa: F722
-        """
-        Cart-pole physics ODEs
-        """
-        cart_velocity = state[:, 1]
-        pole_angle = state[:, 2]
-        pole_angular_velocity = state[:, 3]
+    ) -> Array:
+        """Evaluate the cart-pole ordinary differential equation."""
+
+        # ellipsis ... enables both single-instance and batch instance
+        cart_velocity = state[..., 1]
+        pole_angle = state[..., 2]
+        pole_angular_velocity = state[..., 3]
 
         total_mass = self.cart_mass + self.pole_mass
-        total_mass_adjusted = self.cart_mass + (
+        adjusted_mass = self.cart_mass + (
             self.pole_mass * jnp.sin(pole_angle) ** 2
         )
         pole_mass_length = self.pole_mass * self.pole_length
@@ -118,24 +95,18 @@ class CartPoleSystem(System):
         common_numerator = (
             pole_mass_length * jnp.sin(pole_angle) * pole_angular_velocity**2
         )
-        pole_angular_acceleration_numerator = (
-            total_mass * self.gravity * jnp.sin(pole_angle)
-            - pole_mass_length
-            * pole_angular_velocity** 2
-            * jnp.sin(pole_angle)
-            * jnp.cos(pole_angle)
-        )
-        # This is intended branching: JAX expression saves for no-control
+        angular_acceleration_numerator = total_mass * self.gravity * jnp.sin(
+            pole_angle
+        ) - pole_mass_length * pole_angular_velocity**2 * jnp.sin(
+            pole_angle
+        ) * jnp.cos(pole_angle)
         if control is not None:
-            force = control[:, 0]
-            common_numerator = common_numerator + force
-            pole_angular_acceleration_numerator = (
-                pole_angular_acceleration_numerator
-                - force * jnp.cos(pole_angle)
-            )
+            force = control[..., 0]
+            common_numerator += force
+            angular_acceleration_numerator -= force * jnp.cos(pole_angle)
 
-        pole_angular_acceleration = pole_angular_acceleration_numerator / (
-            total_mass_adjusted * self.pole_length
+        pole_angular_acceleration = angular_acceleration_numerator / (
+            adjusted_mass * self.pole_length
         )
         cart_acceleration = (
             common_numerator
@@ -143,7 +114,7 @@ class CartPoleSystem(System):
             * self.gravity
             * jnp.sin(pole_angle)
             * jnp.cos(pole_angle)
-        ) / total_mass_adjusted
+        ) / adjusted_mass
 
         return jnp.stack(
             (

--- a/src/ss/system/discrete.py
+++ b/src/ss/system/discrete.py
@@ -29,6 +29,7 @@ class HiddenMarkovModel(System):
         self,
         transition_matrix: Array,
         emission_matrix: Array,
+        batch_size: int = 1,
     ) -> None:
         self._transition_matrix = ProbabilityParameter(
             jnp.asarray(transition_matrix),
@@ -43,6 +44,7 @@ class HiddenMarkovModel(System):
             observation_dim=1,
             control_dim=0,
             time_step=1.0,
+            batch_size=batch_size,
         )
 
     @property
@@ -102,38 +104,55 @@ class HiddenMarkovModel(System):
             "emission_matrix rows must sum to 1"
         )
 
-    def init_state(
+    def initial_state(
         self, key: PRNGKeyArray, initial_distribution: Array | None = None
-    ) -> Int[Array, ""]:
+    ) -> Int[Array, "batch_size"]:
         if initial_distribution is None:
             initial_distribution = (
                 jnp.ones(self.discrete_state_dim) / self.discrete_state_dim
             )
-        return jax.random.categorical(key, jnp.log(initial_distribution))
+
+        logits = jnp.log(initial_distribution)
+
+        # Force a single key (2,) to become a batch of one (1, 2)
+        batched_key = jnp.atleast_2d(key)
+
+        assert batched_key.shape[0] == self.batch_size, (
+            f"key batch size {batched_key.shape[0]} must match "
+            f"system batch size {self.batch_size}"
+        )
+
+        # in_axes=(0, None) maps over the batch dimension of 'key' (axis 0),
+        # but uses the exact same 'logits' array (axis None) for every key.
+        return jax.vmap(jax.random.categorical, in_axes=(0, None))(batched_key, logits)
 
     def process(
         self,
         time: float,
-        state: Int[Array, ""],
-        random_key: PRNGKeyArray,
-        control: Array | None = None,
-    ) -> tuple[float, Int[Array, ""]]:
-        return time + self.time_step, jax.random.categorical(
-            random_key, jnp.log(self.transition_matrix[state]),
+        state: Int[Array, "batch_size"],
+        control: Array | None,
+        random_keys: PRNGKeyArray,
+    ) -> tuple[float, Int[Array, "batch_size"]]:
+        return time + self.time_step, jax.vmap(jax.random.categorical)(
+            random_keys,
+            jnp.log(self.transition_matrix[state]),
         )
 
     def observe(
         self,
         time: float,
-        state: Int[Array, ""],
-        random_key: PRNGKeyArray,
-    ) -> Int[Array, ""]:
-        return jax.random.categorical(random_key, jnp.log(self.emission_matrix[state]))
+        state: Int[Array, "batch_size"],
+        random_keys: PRNGKeyArray,
+    ) -> Int[Array, "batch_size"]:
+        return jax.vmap(jax.random.categorical)(
+            random_keys,
+            jnp.log(self.emission_matrix[state])
+        )
 
-    def state_one_hot(self, state: Int[Array, ""]) -> Array:
+    def state_one_hot(self, state: Int[Array, "batch_size discrete_state_dim"]) -> Array:
         return jax.nn.one_hot(state, self.discrete_state_dim)
 
-    def observation_one_hot(self, observation: Int[Array, ""]) -> Array:
+    def observation_one_hot(self, observation: Int[Array, "batch_size discrete_observation_dim"]) -> Array:
         return jax.nn.one_hot(observation, self.discrete_observation_dim)
 
 

--- a/tests/system/system_duplicate_test.py
+++ b/tests/system/system_duplicate_test.py
@@ -23,5 +23,5 @@ def test_duplicate_system_with_new_batch_size() -> None:
     assert duplicate.pole_mass == system.pole_mass
     assert duplicate.pole_length == system.pole_length
     assert duplicate.gravity == system.gravity
-    assert duplicate.init_state().shape == (8, system.state_dim)
-    assert jnp.all(duplicate.init_state() == 0)
+    assert duplicate.initial_state().shape == (8, system.state_dim)
+    assert jnp.all(duplicate.initial_state() == 0)

--- a/tests/system/test_system_duplicate.py
+++ b/tests/system/test_system_duplicate.py
@@ -1,0 +1,27 @@
+import jax.numpy as jnp
+
+from ss.system import CartPoleSystem
+
+
+def test_duplicate_system_with_new_batch_size() -> None:
+    system = CartPoleSystem(
+        time_step=0.02,
+        cart_mass=2.0,
+        pole_mass=0.2,
+        pole_length=1.5,
+        gravity=9.7,
+        batch_size=1,
+    )
+
+    duplicate = system.duplicate(batch_size=8)
+
+    assert duplicate is not system
+    assert system.batch_size == 1
+    assert duplicate.batch_size == 8
+    assert duplicate.time_step == system.time_step
+    assert duplicate.cart_mass == system.cart_mass
+    assert duplicate.pole_mass == system.pole_mass
+    assert duplicate.pole_length == system.pole_length
+    assert duplicate.gravity == system.gravity
+    assert duplicate.init_state().shape == (8, system.state_dim)
+    assert jnp.all(duplicate.init_state() == 0)


### PR DESCRIPTION
Made some attempt to recreate cartpole example with current backend structure.

## Summary

- Add batched JAX cart-pole dynamics and visualization.
- Add the controller interface and batched MPPI implementation.
- Extend `simulate` with controller support using `scan` and `vmap`.
- Add guidance for constructing examples, systems, and controllers.

### Cart-pole

https://github.com/user-attachments/assets/a0f9702d-20ba-43b0-820e-c9f538857f03

<img width="1760" height="1120" alt="cart_pole_plot" src="https://github.com/user-attachments/assets/5e1f4052-8672-4741-9477-e414845fbbe1" />

### MPPI on Cart-pole

https://github.com/user-attachments/assets/e42ed106-3deb-43bc-b412-9571c0facca2

<img width="1920" height="1600" alt="mppi_cart_pole_plot" src="https://github.com/user-attachments/assets/af0dd688-ef98-4bf5-b24e-74951ba25d3f" />

## Minor
- consider adding optional random_key for `init_state`.
- skipped testing and formatting for now.