### PR TITLE
[CI/CD] Consolidate linting on ruff and tune for jaxtyping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,9 +120,8 @@ This installs the package in editable mode along with all development dependenci
 
 **Development Tools:**
 - pre-commit (git hooks)
-- pyupgrade (syntax upgrades)
 - pytest (testing framework)
-- Ruff (linting and formatting)
+- Ruff (linting, formatting, and syntax upgrades)
 - mypy (static type checking)
 - bandit (security checking)
 

--- a/Makefile
+++ b/Makefile
@@ -38,45 +38,38 @@ install-build: ## 🏗️  Install build dependencies.
 .PHONY: install-pre-commit
 install-pre-commit: ## 🕵️  Install pre-commit hooks.
 	@echo "🕵️ Installing pre-commit hooks..."
-	uv run pre-commit install
+	uv run --no-sync pre-commit install
 
 # ==============================================================================
 # CODE QUALITY
 # ==============================================================================
-.PHONY: syntax
-syntax: ## 🔎 Check for syntax upgrades without changing files.
-	@echo "🔎 Checking for syntax upgrades..."
-	find $(PY_SOURCES) -name "*.py" -type f -print0 | xargs -0 -r uv run pyupgrade --py313-plus --exit-zero-even-if-changed
-
 .PHONY: linting
 linting: ## 🔎 Check for linting issues without changing files.
-	make syntax
 	@echo "🔎 Checking for linting issues..."
-	uv run ruff check $(PY_SOURCES)
+	uv run --no-sync ruff check $(PY_SOURCES)
 
 .PHONY: formatting
 formatting: ## ✨ Format and fix code automatically.
-	make syntax
 	@echo "✨ Formatting and fixing code..."
-	uv run ruff format $(PY_SOURCES)
-	uv run ruff check $(PY_SOURCES) --fix
+	uv run --no-sync ruff format $(PY_SOURCES)
+	uv run --no-sync ruff check $(PY_SOURCES) --fix
 
 .PHONY: typing
 typing: ## 🔬 Run static type checking with mypy.
 	@echo "🔬 Running static type checking..."
-	uv run mypy ${PY_SOURCES}
+	uv run --no-sync mypy ${PY_SOURCES}
 
 .PHONY: security
 security: ## 🛡️  Run security checks with bandit.
 	@echo "🛡️  Running security checks..."
-	uv run bandit -r src/ -f json -o bandit-report.json || true
-	uv run bandit -r src/
+	uv run --no-sync bandit -r src/ -f json -o bandit-report.json || true
+	uv run --no-sync bandit -r src/
 
 # ==============================================================================
 # TESTING
 # ==============================================================================
 # The base pytest command.
-PYTEST_CMD = uv run pytest --cov=src --cov-branch -c pyproject.toml
+PYTEST_CMD = uv run --no-sync pytest --cov=src --cov-branch -c pyproject.toml
 
 .PHONY: test
 test: ## ✅ Run tests and show coverage in the terminal.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 
 [![package: uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://docs.astral.sh/uv/)
 [![CI/CD: pre-commit](https://img.shields.io/badge/CI/CD-pre--commit-FAB040?logo=pre-commit)](https://pre-commit.com/)
-[![syntax: pyupgrade](https://img.shields.io/badge/syntax-pyupgrade-blue?logo=pyupgrade)](https://github.com/pyupgrade/pyupgrade)
 [![unit test: pytest](https://img.shields.io/badge/unit_test-pytest-0A9EDC?logo=pytest)](https://docs.pytest.org/)
 [![lint & format:Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![static type: mypy](https://img.shields.io/badge/static_type-mypy-blue)](https://mypy-lang.org/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "pyupgrade>=3.15.2",
     "pre-commit>=3.7.1",
     "pytest>=8.2.1",
+    "pytest-cov>=7.1.0",
     "pytest-mock>=3.14.0",
     "ruff",
     "mypy>=1.10.0",
@@ -143,6 +144,12 @@ exclude = [
 # "E" (pycodestyle errors), "W" (pycodestyle warnings), and "F" (Pyflakes)
 # are a good starting point to replicate flake8's default behavior.
 select = ["E", "F", "W"]
+ignore = [
+    # For JAX + jaxtyping
+    "E731",  # Allow lambda! :)
+    "F722",  # Syntax error in forward annotation (triggered by multi-dimensional jaxtyping shapes)
+    "F821",  # Undefined name (optional, if single-dimension shapes trigger it)
+]
 
 [tool.mypy]
 # https://mypy.readthedocs.io/en/latest/config_file.html#using-a-pyproject-toml-file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
 [dependency-groups]
 dev = [
     "scipy>=1.11.0",
-    "pyupgrade>=3.15.2",
     "pre-commit>=3.7.1",
     "pytest>=8.2.1",
     "pytest-cov>=7.1.0",
@@ -143,13 +142,20 @@ exclude = [
 # Select the rule sets to enable.
 # "E" (pycodestyle errors), "W" (pycodestyle warnings), and "F" (Pyflakes)
 # are a good starting point to replicate flake8's default behavior.
-select = ["E", "F", "W"]
+select = ["E", "F", "W", "UP"]
 ignore = [
     # For JAX + jaxtyping
     "E731",  # Allow lambda! :)
     "F722",  # Syntax error in forward annotation (triggered by multi-dimensional jaxtyping shapes)
     "F821",  # Undefined name (optional, if single-dimension shapes trigger it)
+    "UP037",  # Keep quotes on jaxtyping shape strings (e.g. Float[Array, "state_dim"])
+    # Keep typing.Generic / TypeVar for now (PEP 695 migration is a separate change)
+    "UP046",
+    "UP047",
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
 
 [tool.mypy]
 # https://mypy.readthedocs.io/en/latest/config_file.html#using-a-pyproject-toml-file


### PR DESCRIPTION
## Purpose

- Confirm jaxtyping annotations no longer trip Ruff falsely
- PyUpgrade linting and Ruff style-checking conflict, especially in jax typing. It is easier to tune the linting with Ruff only, instead of managing exception on both end.

## Summary

- Drop `pyupgrade` in favor of Ruff `UP` rules (syntax upgrades via ruff only).
- Add Ruff ignores for JAX/jaxtyping (`E731`, `F722`, `F821`, `UP037`, etc.) and `__init__.py` re-exports.
- Use `uv run --no-sync` for quality/test Makefile targets; add `pytest-cov`.
