### PR TITLE
Refactor carry into structured module

### DIFF
--- a/src/ss/control/mppi.py
+++ b/src/ss/control/mppi.py
@@ -9,11 +9,12 @@ from ss.system import System
 
 from ._control import Controller
 
-type RolloutCarry = tuple[
-    Float[Array, "batch_size"],  # times
-    Float[Array, "batch_size num_rollouts state_dim"],  # states
-    Float[Array, "batch_size num_rollouts"],  # accumulated costs
-]
+class RolloutCarry(eqx.Module):
+    times: Float[Array, "batch_size"]
+    states: Float[Array, "batch_size num_rollouts state_dim"]
+    costs: Float[Array, "batch_size num_rollouts"]
+
+
 type RolloutInputs = tuple[
     Float[Array, "batch_size num_rollouts control_dim"],  # controls
     PRNGKeyArray,  # random key
@@ -118,27 +119,28 @@ class MPPIController(Controller):
             carry: RolloutCarry,
             inputs: RolloutInputs,
         ) -> tuple[RolloutCarry, None]:
-            times, states, total_cost = carry
             controls, process_keys = inputs
             next_times, next_states = jax.vmap(self.rollout_system.process)(
-                times,
-                states,
+                carry.times,
+                carry.states,
                 controls,
                 process_keys,
             )
-            total_cost += self.rollout_system.time_step * jax.vmap(self.running_cost)(next_states, controls)
-            return (next_times, next_states, total_cost), None
+            next_costs = carry.costs + self.rollout_system.time_step * jax.vmap(self.running_cost)(
+                next_states, controls
+            )
+            return RolloutCarry(next_times, next_states, next_costs), None
 
-        (_, final_states, costs), _ = jax.lax.scan(
+        final_carry, _ = jax.lax.scan(
             rollout_step,
-            (
+            RolloutCarry(
                 rollout_times,
                 rollout_states,
                 jnp.zeros((self.batch_size, self.num_rollouts)),
             ),
             (sampled_controls, rollout_keys),
         )
-        costs += jax.vmap(self.terminal_cost)(final_states)
+        costs = final_carry.costs + jax.vmap(self.terminal_cost)(final_carry.states)
         minimum_cost = jnp.min(costs, axis=-1)
         mean_cost = jnp.mean(costs, axis=-1)
         weights = jax.nn.softmax(

--- a/src/ss/control/mppi.py
+++ b/src/ss/control/mppi.py
@@ -9,6 +9,7 @@ from ss.system import System
 
 from ._control import Controller
 
+
 class RolloutCarry(eqx.Module):
     times: Float[Array, "batch_size"]
     states: Float[Array, "batch_size num_rollouts state_dim"]

--- a/src/ss/estimation/filtering/_filtering.py
+++ b/src/ss/estimation/filtering/_filtering.py
@@ -6,7 +6,6 @@ from typing import Self, TypeVar
 
 import equinox as eqx
 import jax
-import jax.numpy as jnp
 from jaxtyping import Array, Float, Shaped
 
 
@@ -72,9 +71,14 @@ class Filter(eqx.Module):
 
 FilterT = TypeVar("FilterT", bound=Filter)
 
-type FilteringCarry = tuple[
+class FilteringCarry(eqx.Module):
+    time: float
+    prior: Float[Array, "batch_size state_dim"]
+
+
+type FilteringStep = tuple[
     float,  # time
-    Float[Array, "batch_size state_dim"],  # prior belief
+    Float[Array, "batch_size state_dim"],  # filtered posterior
 ]
 
 
@@ -108,20 +112,15 @@ def filtering(
     def step(
         carry: FilteringCarry,
         observation: Float[Array, "batch_size observation_dim"],
-    ) -> tuple[
-        FilteringCarry,
-        Float[Array, "batch_size state_dim"],  # filtered posterior
-    ]:
-        time, prior = carry
-        posterior = filter.update(time, prior, observation)
-        next_prior = filter.estimate(time, posterior)
-        next_time = time + filter.time_step
-        return (next_time, next_prior), posterior
+    ) -> tuple[FilteringCarry, FilteringStep]:
+        posterior = filter.update(carry.time, carry.prior, observation)
+        next_prior = filter.estimate(carry.time, posterior)
+        next_time = carry.time + filter.time_step
+        return FilteringCarry(next_time, next_prior), (next_time, posterior)
 
-    _, beliefs = jax.lax.scan(
+    _, (times, beliefs) = jax.lax.scan(
         step,
-        (initial_time, initial_belief),
+        FilteringCarry(initial_time, initial_belief),
         observations,
     )
-    times = initial_time + (jnp.arange(observations.shape[0]) + 1) * (filter.time_step)
     return times, beliefs

--- a/src/ss/system/_system.py
+++ b/src/ss/system/_system.py
@@ -102,11 +102,12 @@ class ContinuousTimeSystem(System):
 
 SystemT = TypeVar("SystemT", bound=System)
 
-type SimulateCarry = tuple[
-    float,  # time
-    Shaped[Array, "batch_size ..."],  # system state
-    ControllerState | None,  # controller state
-]
+class SimulateCarry(eqx.Module):
+    time: float
+    state: Shaped[Array, "batch_size ..."]
+    controller_state: ControllerState | None
+
+
 type SimulateStep = tuple[
     float,  # time
     Shaped[Array, "batch_size ..."],  # state
@@ -166,34 +167,33 @@ def simulate(
         carry: SimulateCarry,
         random_key: PRNGKeyArray,
     ) -> tuple[SimulateCarry, SimulateStep]:
-        previous_time, previous_state, controller_state = carry
-
         observe_key, process_key, controller_key = jax.random.split(random_key, 3)
 
-        observation = system.observe(previous_time, previous_state, observe_key)
+        observation = system.observe(carry.time, carry.state, observe_key)
 
         if controller is None:
             control = None
             next_controller_state = None
-            next_time, state = system.process(previous_time, previous_state, control, process_key)
+            next_time, state = system.process(carry.time, carry.state, control, process_key)
         else:
             control, next_controller_state, _ = controller(
-                controller_state,
-                previous_time,
+                carry.controller_state,
+                carry.time,
                 observation,
                 controller_key,
             )
-            next_time, state = system.process(previous_time, previous_state, control, process_key)
+            next_time, state = system.process(carry.time, carry.state, control, process_key)
 
-        return (
+        return SimulateCarry(next_time, state, next_controller_state), (
             next_time,
             state,
-            next_controller_state,
-        ), (next_time, state, observation, control)
+            observation,
+            control,
+        )
 
     _, (times, states, observations, controls) = jax.lax.scan(
         body,
-        (initial_time, initial_state, controller_state),
+        SimulateCarry(initial_time, initial_state, controller_state),
         keys,
     )
 

--- a/src/ss/system/_system.py
+++ b/src/ss/system/_system.py
@@ -102,6 +102,7 @@ class ContinuousTimeSystem(System):
 
 SystemT = TypeVar("SystemT", bound=System)
 
+
 class SimulateCarry(eqx.Module):
     time: float
     state: Shaped[Array, "batch_size ..."]

--- a/src/ss/system/_system.py
+++ b/src/ss/system/_system.py
@@ -164,7 +164,7 @@ def simulate(
     keys = jax.random.split(random_key, number_of_steps)
 
     @jax.jit
-    def body(
+    def step(
         carry: SimulateCarry,
         random_key: PRNGKeyArray,
     ) -> tuple[SimulateCarry, SimulateStep]:
@@ -193,7 +193,7 @@ def simulate(
         )
 
     _, (times, states, observations, controls) = jax.lax.scan(
-        body,
+        step,
         SimulateCarry(initial_time, initial_state, controller_state),
         keys,
     )

--- a/tests/control/mppi_rollout_carry_test.py
+++ b/tests/control/mppi_rollout_carry_test.py
@@ -1,0 +1,53 @@
+import jax
+import jax.numpy as jnp
+
+from ss.control.mppi import MPPIController, RolloutCarry
+from ss.system import CartPoleSystem
+
+
+def test_rollout_carry_is_a_jittable_pytree() -> None:
+    carry = RolloutCarry(
+        times=jnp.zeros(2),
+        states=jnp.ones((2, 3, 4)),
+        costs=jnp.zeros((2, 3)),
+    )
+
+    @jax.jit
+    def advance(carry: RolloutCarry) -> RolloutCarry:
+        return RolloutCarry(
+            times=carry.times + 0.1,
+            states=carry.states + 1,
+            costs=carry.costs + 2,
+        )
+
+    next_carry = advance(carry)
+
+    assert jnp.allclose(next_carry.times, jnp.full(2, 0.1))
+    assert jnp.array_equal(next_carry.states, jnp.full((2, 3, 4), 2))
+    assert jnp.array_equal(next_carry.costs, jnp.full((2, 3), 2))
+
+
+def test_mppi_rollout_uses_structured_carry() -> None:
+    system = CartPoleSystem(time_step=0.01, batch_size=2)
+    controller = MPPIController(
+        control_dim=system.control_dim,
+        batch_size=system.batch_size,
+        rollout_system=system,
+        running_cost=lambda state, control: jnp.sum(state**2, axis=-1)
+        + jnp.sum(control**2, axis=-1),
+        terminal_cost=lambda state: jnp.sum(state**2, axis=-1),
+        horizon=2,
+        num_rollouts=4,
+    )
+
+    control, next_state, diagnostics = controller(
+        controller.initial_state(),
+        jnp.array(0.0),
+        system.initial_state(),
+        jax.random.PRNGKey(0),
+    )
+
+    assert control.shape == (system.batch_size, system.control_dim)
+    assert next_state.nominal_controls.shape == (system.batch_size, 2, system.control_dim)
+    assert diagnostics.minimum_rollout_cost.shape == (system.batch_size,)
+    assert jnp.all(jnp.isfinite(control))

--- a/tests/control/mppi_rollout_carry_test.py
+++ b/tests/control/mppi_rollout_carry_test.py
@@ -5,48 +5,49 @@ from ss.control.mppi import MPPIController, RolloutCarry
 from ss.system import CartPoleSystem
 
 
-def test_rollout_carry_is_a_jittable_pytree() -> None:
-    carry = RolloutCarry(
-        times=jnp.zeros(2),
-        states=jnp.ones((2, 3, 4)),
-        costs=jnp.zeros((2, 3)),
-    )
-
-    @jax.jit
-    def advance(carry: RolloutCarry) -> RolloutCarry:
-        return RolloutCarry(
-            times=carry.times + 0.1,
-            states=carry.states + 1,
-            costs=carry.costs + 2,
+class TestRolloutCarry:
+    def test_is_a_jittable_pytree(self) -> None:
+        carry = RolloutCarry(
+            times=jnp.zeros(2),
+            states=jnp.ones((2, 3, 4)),
+            costs=jnp.zeros((2, 3)),
         )
 
-    next_carry = advance(carry)
+        @jax.jit
+        def advance(carry: RolloutCarry) -> RolloutCarry:
+            return RolloutCarry(
+                times=carry.times + 0.1,
+                states=carry.states + 1,
+                costs=carry.costs + 2,
+            )
 
-    assert jnp.allclose(next_carry.times, jnp.full(2, 0.1))
-    assert jnp.array_equal(next_carry.states, jnp.full((2, 3, 4), 2))
-    assert jnp.array_equal(next_carry.costs, jnp.full((2, 3), 2))
+        next_carry = advance(carry)
 
+        assert jnp.allclose(next_carry.times, jnp.full(2, 0.1))
+        assert jnp.array_equal(next_carry.states, jnp.full((2, 3, 4), 2))
+        assert jnp.array_equal(next_carry.costs, jnp.full((2, 3), 2))
 
-def test_mppi_rollout_uses_structured_carry() -> None:
-    system = CartPoleSystem(time_step=0.01, batch_size=2)
-    controller = MPPIController(
-        control_dim=system.control_dim,
-        batch_size=system.batch_size,
-        rollout_system=system,
-        running_cost=lambda state, control: jnp.sum(state**2, axis=-1) + jnp.sum(control**2, axis=-1),
-        terminal_cost=lambda state: jnp.sum(state**2, axis=-1),
-        horizon=2,
-        num_rollouts=4,
-    )
+    def test_mppi_rollout_uses_structured_carry(self) -> None:
+        system = CartPoleSystem(time_step=0.01, batch_size=2)
+        controller = MPPIController(
+            control_dim=system.control_dim,
+            batch_size=system.batch_size,
+            rollout_system=system,
+            running_cost=lambda state, control: jnp.sum(state**2, axis=-1)
+            + jnp.sum(control**2, axis=-1),
+            terminal_cost=lambda state: jnp.sum(state**2, axis=-1),
+            horizon=2,
+            num_rollouts=4,
+        )
 
-    control, next_state, diagnostics = controller(
-        controller.initial_state(),
-        jnp.array(0.0),
-        system.initial_state(),
-        jax.random.PRNGKey(0),
-    )
+        control, next_state, diagnostics = controller(
+            controller.initial_state(),
+            jnp.array(0.0),
+            system.initial_state(),
+            jax.random.PRNGKey(0),
+        )
 
-    assert control.shape == (system.batch_size, system.control_dim)
-    assert next_state.nominal_controls.shape == (system.batch_size, 2, system.control_dim)
-    assert diagnostics.minimum_rollout_cost.shape == (system.batch_size,)
-    assert jnp.all(jnp.isfinite(control))
+        assert control.shape == (system.batch_size, system.control_dim)
+        assert next_state.nominal_controls.shape == (system.batch_size, 2, system.control_dim)
+        assert diagnostics.minimum_rollout_cost.shape == (system.batch_size,)
+        assert jnp.all(jnp.isfinite(control))

--- a/tests/control/mppi_rollout_carry_test.py
+++ b/tests/control/mppi_rollout_carry_test.py
@@ -33,8 +33,7 @@ def test_mppi_rollout_uses_structured_carry() -> None:
         control_dim=system.control_dim,
         batch_size=system.batch_size,
         rollout_system=system,
-        running_cost=lambda state, control: jnp.sum(state**2, axis=-1)
-        + jnp.sum(control**2, axis=-1),
+        running_cost=lambda state, control: jnp.sum(state**2, axis=-1) + jnp.sum(control**2, axis=-1),
         terminal_cost=lambda state: jnp.sum(state**2, axis=-1),
         horizon=2,
         num_rollouts=4,

--- a/tests/estimation/filtering/filtering_carry_test.py
+++ b/tests/estimation/filtering/filtering_carry_test.py
@@ -1,0 +1,23 @@
+import jax
+import jax.numpy as jnp
+
+from ss.estimation.filtering._filtering import FilteringCarry
+
+
+def test_filtering_carry_is_a_jittable_pytree() -> None:
+    carry = FilteringCarry(
+        time=0.0,
+        prior=jnp.ones((2, 3)),
+    )
+
+    @jax.jit
+    def advance(carry: FilteringCarry) -> FilteringCarry:
+        return FilteringCarry(
+            time=carry.time + 0.1,
+            prior=carry.prior + 1,
+        )
+
+    next_carry = advance(carry)
+
+    assert jnp.allclose(next_carry.time, 0.1)
+    assert jnp.array_equal(next_carry.prior, jnp.full((2, 3), 2))

--- a/tests/estimation/filtering/filtering_carry_test.py
+++ b/tests/estimation/filtering/filtering_carry_test.py
@@ -4,20 +4,21 @@ import jax.numpy as jnp
 from ss.estimation.filtering._filtering import FilteringCarry
 
 
-def test_filtering_carry_is_a_jittable_pytree() -> None:
-    carry = FilteringCarry(
-        time=0.0,
-        prior=jnp.ones((2, 3)),
-    )
-
-    @jax.jit
-    def advance(carry: FilteringCarry) -> FilteringCarry:
-        return FilteringCarry(
-            time=carry.time + 0.1,
-            prior=carry.prior + 1,
+class TestFilteringCarry:
+    def test_is_a_jittable_pytree(self) -> None:
+        carry = FilteringCarry(
+            time=0.0,
+            prior=jnp.ones((2, 3)),
         )
 
-    next_carry = advance(carry)
+        @jax.jit
+        def advance(carry: FilteringCarry) -> FilteringCarry:
+            return FilteringCarry(
+                time=carry.time + 0.1,
+                prior=carry.prior + 1,
+            )
 
-    assert jnp.allclose(next_carry.time, 0.1)
-    assert jnp.array_equal(next_carry.prior, jnp.full((2, 3), 2))
+        next_carry = advance(carry)
+
+        assert jnp.allclose(next_carry.time, 0.1)
+        assert jnp.array_equal(next_carry.prior, jnp.full((2, 3), 2))

--- a/tests/system/simulate_carry_test.py
+++ b/tests/system/simulate_carry_test.py
@@ -1,0 +1,38 @@
+import jax
+import jax.numpy as jnp
+
+from ss.system._system import SimulateCarry
+
+
+def test_simulate_carry_is_a_jittable_pytree() -> None:
+    carry = SimulateCarry(
+        time=0.0,
+        state=jnp.ones((2, 3)),
+        controller_state={"step": jnp.array(0)},
+    )
+
+    @jax.jit
+    def advance(carry: SimulateCarry) -> SimulateCarry:
+        return SimulateCarry(
+            time=carry.time + 0.1,
+            state=carry.state + 1,
+            controller_state={"step": carry.controller_state["step"] + 1},
+        )
+
+    next_carry = advance(carry)
+
+    assert jnp.allclose(next_carry.time, 0.1)
+    assert jnp.array_equal(next_carry.state, jnp.full((2, 3), 2))
+    assert next_carry.controller_state["step"] == 1
+
+
+def test_simulate_carry_supports_no_controller_state() -> None:
+    carry = SimulateCarry(
+        time=0.0,
+        state=jnp.ones((1, 2)),
+        controller_state=None,
+    )
+
+    leaves = jax.tree.leaves(carry)
+
+    assert len(leaves) == 2

--- a/tests/system/simulate_carry_test.py
+++ b/tests/system/simulate_carry_test.py
@@ -4,35 +4,35 @@ import jax.numpy as jnp
 from ss.system._system import SimulateCarry
 
 
-def test_simulate_carry_is_a_jittable_pytree() -> None:
-    carry = SimulateCarry(
-        time=0.0,
-        state=jnp.ones((2, 3)),
-        controller_state={"step": jnp.array(0)},
-    )
-
-    @jax.jit
-    def advance(carry: SimulateCarry) -> SimulateCarry:
-        return SimulateCarry(
-            time=carry.time + 0.1,
-            state=carry.state + 1,
-            controller_state={"step": carry.controller_state["step"] + 1},
+class TestSimulateCarry:
+    def test_is_a_jittable_pytree(self) -> None:
+        carry = SimulateCarry(
+            time=0.0,
+            state=jnp.ones((2, 3)),
+            controller_state={"step": jnp.array(0)},
         )
 
-    next_carry = advance(carry)
+        @jax.jit
+        def advance(carry: SimulateCarry) -> SimulateCarry:
+            return SimulateCarry(
+                time=carry.time + 0.1,
+                state=carry.state + 1,
+                controller_state={"step": carry.controller_state["step"] + 1},
+            )
 
-    assert jnp.allclose(next_carry.time, 0.1)
-    assert jnp.array_equal(next_carry.state, jnp.full((2, 3), 2))
-    assert next_carry.controller_state["step"] == 1
+        next_carry = advance(carry)
 
+        assert jnp.allclose(next_carry.time, 0.1)
+        assert jnp.array_equal(next_carry.state, jnp.full((2, 3), 2))
+        assert next_carry.controller_state["step"] == 1
 
-def test_simulate_carry_supports_no_controller_state() -> None:
-    carry = SimulateCarry(
-        time=0.0,
-        state=jnp.ones((1, 2)),
-        controller_state=None,
-    )
+    def test_supports_no_controller_state(self) -> None:
+        carry = SimulateCarry(
+            time=0.0,
+            state=jnp.ones((1, 2)),
+            controller_state=None,
+        )
 
-    leaves = jax.tree.leaves(carry)
+        leaves = jax.tree.leaves(carry)
 
-    assert len(leaves) == 2
+        assert len(leaves) == 2


### PR DESCRIPTION
closes #66 

## Summary

- replace the tuple-based `SimulateCarry` with an `eqx.Module`
- use named carry fields throughout the simulation scan
- replace MPPI's tuple-based `RolloutCarry` with an `eqx.Module`

This removes positional carry unpacking.

## Testing

- [x] test
- [x] formatting
- [x] typing
